### PR TITLE
When the input has wildcard (*), default to keep-directories: suffix

### DIFF
--- a/tests/test_yaml/test4.expected.valohai.yaml
+++ b/tests/test_yaml/test4.expected.valohai.yaml
@@ -25,7 +25,8 @@
     inputs:
     - name: input1
       default:
-      - asdf
+      - asdf/*
+      keep-directories: suffix
       optional: false
     - name: input2
       default:

--- a/tests/test_yaml/test4.py
+++ b/tests/test_yaml/test4.py
@@ -9,7 +9,7 @@ params = {
     "param4": 0.0001,
 }
 
-inputs = {"input1": "asdf", "input2": ["yolol", "yalala"]}
+inputs = {"input1": "asdf/*", "input2": ["yolol", "yalala"]}
 
 
 def prepare(a, b):

--- a/valohai/internals/yaml.py
+++ b/valohai/internals/yaml.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 from valohai.consts import DEFAULT_DOCKER_IMAGE
 from valohai.internals.parsing import parse
 from valohai_yaml.objs import Config, Parameter, Step
-from valohai_yaml.objs.input import Input
+from valohai_yaml.objs.input import Input, KeepDirectories
 
 ParameterDict = Dict[str, Any]
 InputDict = Dict[str, str]
@@ -28,7 +28,9 @@ def generate_step(
         )
 
     for key, value in inputs.items():
-        config_step.inputs[key] = Input(name=key, default=value,)
+        has_wildcards = any('*' in uri for uri in value)
+        keep_directories = KeepDirectories.SUFFIX.value if has_wildcards else False
+        config_step.inputs[key] = Input(name=key, default=value, keep_directories=keep_directories)
 
     return config_step
 


### PR DESCRIPTION
If a user defaults to an input with a wildcard `*`, we default to `keep-directories: suffix` for the generated config.

According to @DrazenDodik, this is what the customer wants 95% time when they use a wildcard. Everything else is an edge case, which you can handle by manually editing the config.