### PR TITLE
Flush with a newline, printing JSON on own line

### DIFF
--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -5,12 +5,12 @@ def test_basic_logging(capsys):
     with valohai.logger() as logger:
         logger.log("myint", 123)
     captured = capsys.readouterr()
-    assert captured.out == '{"myint": 123}\n'
+    assert captured.out == '\n{"myint": 123}\n'
 
     with valohai.logger() as logger:
         logger.log("I am float", 0.1241234435877)
     captured = capsys.readouterr()
-    assert captured.out == '{"I am float": 0.1241234435877}\n'
+    assert captured.out == '\n{"I am float": 0.1241234435877}\n'
 
 
 def test_partial_logging(capsys):
@@ -18,7 +18,7 @@ def test_partial_logging(capsys):
         logger.log("myint", 123)
         logger.log("myfloat", 0.5435)
     captured = capsys.readouterr()
-    assert captured.out == '{"myint": 123, "myfloat": 0.5435}\n'
+    assert captured.out == '\n{"myint": 123, "myfloat": 0.5435}\n'
 
     logger = valohai.logger()
     logger.log("myint", 234)
@@ -26,4 +26,4 @@ def test_partial_logging(capsys):
     logger.log("extrathing", 2)
     logger.flush()
     captured = capsys.readouterr()
-    assert captured.out == '{"myint": 234, "myfloat": 0.2322323, "extrathing": 2}\n'
+    assert captured.out == '\n{"myint": 234, "myfloat": 0.2322323, "extrathing": 2}\n'

--- a/valohai/metadata.py
+++ b/valohai/metadata.py
@@ -70,7 +70,8 @@ class Logger:
         This will log all three metrics at once.
         """
         if self.partial_logs:
-            print(json.dumps(self.partial_logs, default=str))
+            # Start with \n, ensuring JSON prints on it's own line
+            print(f'\n{json.dumps(self.partial_logs, default=str)}')
             self.partial_logs.clear()
 
     def _serialize(self, name, value):


### PR DESCRIPTION
Starting flushes with a newline, we ensure the JSON gets printed on it's own line and Valohai recognizes it.