### PR TITLE
Add support for defining pipelines via papi integration (fixes #26)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,3 +9,6 @@ ignore_missing_imports = True
 
 [mypy-tqdm.*]
 ignore_missing_imports = True
+
+[mypy-papi.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,6 @@ setuptools.setup(
     author_email="hait@valohai.com",
     license="MIT",
     packages=setuptools.find_packages(include=("valohai*",)),
-    install_requires=[
-        "tqdm",
-        "requests",
-        "valohai-yaml>=0.13.0",
-    ],
+    install_requires=["tqdm", "requests", "valohai-yaml>=0.13.0", "valohai-papi"],
     python_requires=">=3.6",
 )

--- a/tests/test_pipeline_yaml/test1.expected.valohai.yaml
+++ b/tests/test_pipeline_yaml/test1.expected.valohai.yaml
@@ -1,0 +1,57 @@
+- step:
+    name: Batch feature extraction
+    image: ubuntu:18.04
+    command:
+    - date > /valohai/outputs/aaa.md5
+    - date > /valohai/outputs/bbb.sha256
+- step:
+    name: Evaluate
+    image: ubuntu:18.04
+    command:
+    - ls -lar
+    inputs:
+    - name: models
+      optional: false
+- step:
+    name: Train model
+    image: ubuntu:18.04
+    command:
+    - find /valohai/inputs -type f -exec sha1sum '{}' ';' > /valohai/outputs/model.txt
+    parameters:
+    - name: learning_rate
+      default: 0.001
+      description: Initial learning rate
+      multiple-separator: ','
+      optional: false
+      pass-as: --learning_rate={v}
+      type: float
+    inputs:
+    - name: aaa
+      optional: false
+    - name: bbb
+      optional: false
+- pipeline:
+    name: mypipeline
+    edges:
+    - configuration: {}
+      source: batch_feature_extraction_1.output.a*
+      target: train_model_1.input.aaa
+    - configuration: {}
+      source: batch_feature_extraction_1.output.a*
+      target: train_model_1.input.bbb
+    - configuration: {}
+      source: train_model_1.output.*
+      target: evaluate_1.input.models
+    nodes:
+    - name: batch_feature_extraction_1
+      override: {}
+      step: Batch feature extraction
+      type: execution
+    - name: train_model_1
+      override: {}
+      step: Train model
+      type: task
+    - name: evaluate_1
+      override: {}
+      step: Evaluate
+      type: execution

--- a/tests/test_pipeline_yaml/test1.original.valohai.yaml
+++ b/tests/test_pipeline_yaml/test1.original.valohai.yaml
@@ -1,0 +1,27 @@
+- step:
+    name: Batch feature extraction
+    image: ubuntu:18.04
+    command:
+      - date > /valohai/outputs/aaa.md5
+      - date > /valohai/outputs/bbb.sha256
+- step:
+    name: Train model
+    image: ubuntu:18.04
+    command:
+      - find /valohai/inputs -type f -exec sha1sum '{}' ';' > /valohai/outputs/model.txt
+    parameters:
+      - name: learning_rate
+        pass-as: --learning_rate={v}
+        description: Initial learning rate
+        type: float
+        default: 0.001
+    inputs:
+      - name: aaa
+      - name: bbb
+- step:
+    name: Evaluate
+    image: ubuntu:18.04
+    inputs:
+      - name: models
+    command:
+      - ls -lar

--- a/tests/test_pipeline_yaml/test1.py
+++ b/tests/test_pipeline_yaml/test1.py
@@ -1,0 +1,20 @@
+from valohai import Pipeline
+
+
+def main(config) -> Pipeline:
+    pipe = Pipeline(name="mypipeline", config=config)
+
+    # Define nodes
+    extract = pipe.execution("Batch feature extraction")
+    train = pipe.task("Train model")
+    evaluate = pipe.execution("Evaluate")
+
+    # Configure training task node
+    train.linear_parameter("learning_rate", min=0, max=1, step=0.1)
+
+    # Configure pipeline
+    extract.output("a*").to(train.input("aaa"))
+    extract.output("a*").to(train.input("bbb"))
+    train.output("*").to(evaluate.input("models"))
+
+    return pipe

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,3 +26,31 @@ def get_parsing_tests():
     for python_file in glob.glob(os.path.join(basepath, "*.py")):
         path_without_ext = os.path.splitext(python_file)[0]
         yield read_source_files(path_without_ext)
+
+
+def read_yaml_test_data(root_path):
+    """
+    Returns a list of test sets. Each set is representing a single YAML updating test case.
+
+    Expected in the root_path:
+        mytest.py -- Python file defining a step or a pipeline
+        mytest.original.valohai.yaml -- Original valohai.yaml
+        mytest.expected.valohai.yaml -- Expected valohai.yaml after update
+        mytest2.py -- Another Python file defining a step or a pipeline
+        mytest2.original.valohai.yaml -- Original valohai.yaml
+        mytest2.expected.valohai.yaml -- Expected valohai.yaml after update
+        etc...
+
+    """
+    test_data = []
+    for source_path in glob.glob(f"{root_path}/*.py"):
+        dirname = os.path.dirname(source_path)
+        name, extension = os.path.splitext(os.path.basename(source_path))
+        test_data.append(
+            (
+                f"{dirname}/{name}.original.valohai.yaml",
+                source_path,
+                f"{dirname}/{name}.expected.valohai.yaml",
+            )
+        )
+    return test_data

--- a/valohai/__init__.py
+++ b/valohai/__init__.py
@@ -1,9 +1,13 @@
 __version__ = "0.1.5"
 
+import papi
+
 from .inputs import inputs
 from .metadata import logger
 from .outputs import outputs
 from .parameters import parameters
 from .utils import prepare
 
-__all__ = ["inputs", "logger", "outputs", "parameters", "prepare"]
+Pipeline = papi.Papi
+
+__all__ = ["inputs", "logger", "outputs", "parameters", "prepare", "Pipeline"]

--- a/valohai/internals/pipeline.py
+++ b/valohai/internals/pipeline.py
@@ -1,0 +1,28 @@
+from valohai_yaml.objs import Config
+
+
+def get_pipeline_from_source(source_path: str, old_config: Config) -> Config:
+    """Gets the pipeline definition by executing the main() in the source Python file.
+
+    The file is expected to contain:
+
+    def main(config) -> Pipeline:
+        pipeline = Pipeline(name="foo", config=config)
+        # ... Pipeline definition ...
+        return pipeline
+
+    :param source_path: Path of the Python source code file containing the pipeline definition
+    :param old_config: Currently config for the Valohai project (used for validation)
+
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        name="pipeline_source", location=source_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if not hasattr(module, "main"):
+        raise AttributeError(f"{source_path} is missing main() method!")
+    pipe = module.main(old_config)
+    return Config(pipelines=[pipe.to_yaml()])


### PR DESCRIPTION
Integrating `valohai-papi` into `valohai-utils`.

Technically we could integrate `valohai-papi` directly into `valohai-cli`, but I feel like all the Python to YAML shenanigans should live in the `valohai-utils`. As a bonus, the user now needs to import from one place only (`import valohai`).

The integration happens through single method `get_pipeline_from_source()` and the rest of the PR is testing.