### PR TITLE
Style + lint + mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
-name: Test
+name: CI
 
 on: [push]
 
 jobs:
-  build:
+  Test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -18,6 +18,28 @@ jobs:
         python -m pip install -e .
     - name: Test with pytest
       run: pytest -ra --cov .
+    - name: Cache deps
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements-dev.txt
+        python -m pip install -e .
+    - name: Lint
+      run: make lint
     - name: Cache deps
       uses: actions/cache@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,4 @@ lint:
 	flake8 .
 	black --check .
 	isort -c .
+	mypy .

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+exclude = tests/test_.*
+
+[mypy-valohai_yaml.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True
+
+[mypy-tqdm.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ["py36"]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,10 @@
 black
 bump2version
 flake8
+flake8-bugbear
+flake8-print
+flake8-return
+flake8-simplify
 isort
 pip-tools
 pydocstyle

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,6 +6,7 @@ flake8-print
 flake8-return
 flake8-simplify
 isort
+mypy
 pip-tools
 pydocstyle
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,11 @@
 #
 appdirs==1.4.4
     # via black
+astor==0.8.1
+    # via flake8-simplify
 attrs==20.3.0
     # via
+    #   flake8-bugbear
     #   jsonschema
     #   pytest
 black==20.8b1
@@ -24,13 +27,27 @@ click==7.1.2
     #   pip-tools
 coverage==5.5
     # via pytest-cov
-flake8==3.8.4
+flake8-bugbear==21.4.3
     # via -r requirements-dev.in
+flake8-plugin-utils==1.3.1
+    # via flake8-return
+flake8-print==4.0.0
+    # via -r requirements-dev.in
+flake8-return==1.1.2
+    # via -r requirements-dev.in
+flake8-simplify==0.14.0
+    # via -r requirements-dev.in
+flake8==3.9.1
+    # via
+    #   -r requirements-dev.in
+    #   flake8-bugbear
+    #   flake8-print
+    #   flake8-simplify
 idna==2.10
     # via requests
 iniconfig==1.1.1
     # via pytest
-isort==5.7.0
+isort==5.8.0
     # via -r requirements-dev.in
 jsonschema==3.2.0
     # via valohai-yaml
@@ -42,17 +59,21 @@ packaging==20.9
     # via pytest
 pathspec==0.8.1
     # via black
-pip-tools==5.5.0
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.1.0
     # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
 py==1.10.0
     # via pytest
-pycodestyle==2.6.0
-    # via flake8
-pydocstyle==5.1.1
+pycodestyle==2.7.0
+    # via
+    #   flake8
+    #   flake8-print
+pydocstyle==6.0.0
     # via -r requirements-dev.in
-pyflakes==2.2.0
+pyflakes==2.3.1
     # via flake8
 pyparsing==2.4.7
     # via packaging
@@ -60,13 +81,13 @@ pyrsistent==0.17.3
     # via jsonschema
 pytest-cov==2.11.1
     # via -r requirements-dev.in
-pytest==6.2.2
+pytest==6.2.3
     # via
     #   -r requirements-dev.in
     #   pytest-cov
 pyyaml==5.4.1
     # via valohai-yaml
-regex==2020.11.13
+regex==2021.4.4
     # via black
 requests-mock==1.8.0
     # via -r requirements-dev.in
@@ -76,6 +97,7 @@ requests==2.25.1
     #   requests-mock
 six==1.15.0
     # via
+    #   flake8-print
     #   jsonschema
     #   requests-mock
 snowballstemmer==2.1.0
@@ -83,16 +105,17 @@ snowballstemmer==2.1.0
 toml==0.10.2
     # via
     #   black
+    #   pep517
     #   pytest
-tqdm==4.58.0
+tqdm==4.60.0
     # via -r requirements-dev.in
-typed-ast==1.4.2
+typed-ast==1.4.3
     # via black
 typing-extensions==3.7.4.3
     # via black
-urllib3==1.26.3
+urllib3==1.26.4
     # via requests
-valohai-yaml==0.13.0
+valohai-yaml==0.14.1
     # via -r requirements-dev.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -54,7 +54,11 @@ jsonschema==3.2.0
 mccabe==0.6.1
     # via flake8
 mypy-extensions==0.4.3
-    # via black
+    # via
+    #   black
+    #   mypy
+mypy==0.812
+    # via -r requirements-dev.in
 packaging==20.9
     # via pytest
 pathspec==0.8.1
@@ -110,9 +114,13 @@ toml==0.10.2
 tqdm==4.60.0
     # via -r requirements-dev.in
 typed-ast==1.4.3
-    # via black
+    # via
+    #   black
+    #   mypy
 typing-extensions==3.7.4.3
-    # via black
+    # via
+    #   black
+    #   mypy
 urllib3==1.26.4
     # via requests
 valohai-yaml==0.14.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,10 @@
 universal = 0
 
 [flake8]
-ignore = E501,W503
+ignore = E501,W503,SIM105,SIM106,R504
 max-complexity = 10
+per-file-ignores =
+    tests/*: T001,T002,T003,T004
 
 [pydocstyle]
 ignore = D100,D104,D203,D212

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 0
 
 [flake8]
-max-line-length = 88
+ignore = E501,W503
 max-complexity = 10
 
 [pydocstyle]
@@ -12,14 +12,7 @@ ignore = D100,D104,D203,D212
 norecursedirs = .git .tox
 
 [isort]
-atomic = true
-combine_as_imports = false
-indent = 4
-length_sort = false
-line_length = 120
-multi_line_output = 5
-order_by_type = false
-wrap_length = 120
+profile = black
 
 [coverage:run]
 omit =

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import re
 
 import setuptools
 
-with open(os.path.join(os.path.dirname(__file__), 'valohai', '__init__.py')) as infp:
+with open(os.path.join(os.path.dirname(__file__), "valohai", "__init__.py")) as infp:
     version = ast.literal_eval(
-        re.search('__version__ = (.+?)$', infp.read(), re.M).group(1)
+        re.search("__version__ = (.+?)$", infp.read(), re.M).group(1)
     )
 
 setuptools.setup(
@@ -21,5 +21,5 @@ setuptools.setup(
         "requests",
         "valohai-yaml>=0.13.0",
     ],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,20 @@ import re
 
 import setuptools
 
-with open(os.path.join(os.path.dirname(__file__), "valohai", "__init__.py")) as infp:
-    version = ast.literal_eval(
-        re.search("__version__ = (.+?)$", infp.read(), re.M).group(1)
-    )
+
+def get_version():
+    with open(
+        os.path.join(os.path.dirname(__file__), "valohai", "__init__.py")
+    ) as infp:
+        match = re.search("__version__ = (.+?)$", infp.read(), re.M)
+        if not match:
+            raise ValueError("No version could be found")
+        return ast.literal_eval(match.group(1))
+
 
 setuptools.setup(
     name="valohai-utils",
-    version=version,
+    version=get_version(),
     author="Valohai",
     author_email="hait@valohai.com",
     license="MIT",

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import valohai
-from valohai.internals.input_info import InputInfo, load_input_info
+from valohai.internals.input_info import load_input_info
 
 
 def test_download(tmpdir, monkeypatch, requests_mock):

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -20,6 +20,6 @@ def test_live_upload(outputs_path):
         fp.write("hello")
     valohai.outputs().live_upload(path)
 
-    with pytest.raises(IOError):
-        # Test the file is set read-only
-        open(path, "w")
+    # Test the file is set read-only
+    with pytest.raises(IOError), open(path, "w"):
+        pass

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -3,7 +3,6 @@ import pytest
 from valohai.internals.parsing import parse
 
 from .utils import get_parsing_tests
-from valohai.consts import DEFAULT_DOCKER_IMAGE
 
 
 def read_test_data():
@@ -20,7 +19,7 @@ def read_test_data():
             info["parameters"],
             info["inputs"],
             info["step"]["name"],
-            info["step"]["image"] if 'image' in info["step"] else None,
+            info["step"]["image"] if "image" in info["step"] else None,
         )
 
 

--- a/tests/test_parsing/test1.py
+++ b/tests/test_parsing/test1.py
@@ -1,5 +1,3 @@
-import os
-
 import pandas as pd
 
 import valohai

--- a/tests/test_parsing/test2.py
+++ b/tests/test_parsing/test2.py
@@ -1,5 +1,1 @@
-import os
-
-import valohai
-
 print("test file with no prepare")

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -3,7 +3,7 @@ import sys
 
 import valohai
 from valohai.internals.download_type import DownloadType
-from valohai.internals.input_info import InputInfo, load_input_info
+from valohai.internals.input_info import load_input_info
 
 
 def test_prepare(tmpdir, monkeypatch):
@@ -50,11 +50,11 @@ def test_prepare(tmpdir, monkeypatch):
             step="test", default_parameters=parameters, default_inputs=inputs
         )
 
-    assert valohai.parameters("iambool").value == True
+    assert valohai.parameters("iambool").value is True
     assert valohai.parameters("mestringy").value == "asdf"
     assert valohai.parameters("integerboi").value == 123
     assert valohai.parameters("floaty").value == 0.0001
-    assert valohai.parameters("makemetrue").value == True
+    assert valohai.parameters("makemetrue").value is True
     assert valohai.parameters("makemeqwer").value == "qwer"
     assert valohai.parameters("makeme321").value == 321
     assert valohai.parameters("makemenegative").value < 0.0

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -3,7 +3,7 @@ import os
 import tarfile
 import zipfile
 
-from valohai.internals.vfs import find_files, VFS
+from valohai.internals.vfs import VFS, find_files
 
 
 def _add_binary_to_tar(tf: tarfile.TarFile, name: str, content: bytes):

--- a/tests/test_yaml/test1.py
+++ b/tests/test_yaml/test1.py
@@ -1,5 +1,3 @@
-import os
-
 import valohai
 
 params = {

--- a/tests/test_yaml/test2.py
+++ b/tests/test_yaml/test2.py
@@ -1,5 +1,3 @@
-import os
-
 import valohai
 
 params = {

--- a/tests/test_yaml/test3.py
+++ b/tests/test_yaml/test3.py
@@ -1,5 +1,3 @@
-import os
-
 import valohai
 
 params = {

--- a/tests/test_yaml/test4.py
+++ b/tests/test_yaml/test4.py
@@ -1,5 +1,3 @@
-import os
-
 import valohai
 
 params = {

--- a/tests/test_yaml/test5.py
+++ b/tests/test_yaml/test5.py
@@ -5,7 +5,9 @@ params = {
     "num_epochs": 200,
 }
 
+
 def prepare(a, b):
     print(f"this is fake method {a} {b}")
-    
+
+
 valohai.prepare(step="mystep", default_parameters=params, image="valohai/keras")

--- a/valohai/__init__.py
+++ b/valohai/__init__.py
@@ -5,3 +5,5 @@ from .metadata import logger
 from .outputs import outputs
 from .parameters import parameters
 from .utils import prepare
+
+__all__ = ["inputs", "logger", "outputs", "parameters", "prepare"]

--- a/valohai/config.py
+++ b/valohai/config.py
@@ -1,5 +1,5 @@
 import os
 
 
-def is_running_in_valohai():
+def is_running_in_valohai() -> bool:
     return bool(os.environ.get("VH_JOB_ID"))

--- a/valohai/inputs.py
+++ b/valohai/inputs.py
@@ -15,7 +15,7 @@ class Input:
         default: Optional[Iterable[str]] = None,
         process_archives: bool = True,
         force_download: bool = False,
-    ) -> Optional[Iterable[str]]:
+    ) -> Iterator[str]:
         """Get paths to all files for a given input name.
 
         Returns a list of file system paths for an input.
@@ -120,6 +120,7 @@ class Input:
         )
         if ii:
             for file_info in ii.files:
+                assert file_info.path
                 vfs.add_disk_file(
                     v,
                     name=file_info.name,

--- a/valohai/inputs.py
+++ b/valohai/inputs.py
@@ -7,7 +7,7 @@ from .internals.input_info import load_input_info
 
 
 class Input:
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = str(name)
 
     def paths(

--- a/valohai/inputs.py
+++ b/valohai/inputs.py
@@ -28,18 +28,22 @@ class Input:
         :param force_download: Force re-download of file(s) even when they are cached already.
         :return: List of file system paths for all the files for this input.
         """
-        if default is None:
-            default = []
 
+        found_file = False
         for file in self._get_input_vfs(
             process_archives=process_archives, force_download=force_download
         ).files:
             if isinstance(file, vfs.FileInContainer):
                 yield file.open_concrete(delete=False).name
+                found_file = True
             elif isinstance(file, vfs.FileOnDisk):
                 yield file.path
+                found_file = True
 
-        return default
+        if not found_file:
+            if default is None:
+                default = []
+            yield from default
 
     def path(
         self,

--- a/valohai/internals/compression.py
+++ b/valohai/internals/compression.py
@@ -60,12 +60,18 @@ class BaseArchive:
 
 
 class ZipArchive(BaseArchive, zipfile.ZipFile):
-    def __init__(self, file, mode="r", *, compresslevel=1):
+    def __init__(self, file: str, mode: str = "r", *, compresslevel: int = 1) -> None:
         # Only Python 3.7+ has the compresslevel kwarg here
         super().__init__(file, mode, compression=zipfile.ZIP_STORED)
         self.compresslevel = compresslevel
 
-    def writestream(self, arcname, data, compress_type, compresslevel):
+    def writestream(
+        self,
+        arcname: str,
+        data: Union[str, bytes, IO[bytes]],
+        compress_type: int,
+        compresslevel: int,
+    ) -> None:
         # Like `writestr`, but also supports a stream (and doesn't support directories).
         zinfo = zipfile.ZipInfo(filename=arcname)
         zinfo.compress_type = compress_type
@@ -82,7 +88,7 @@ class ZipArchive(BaseArchive, zipfile.ZipFile):
                 shutil.copyfileobj(data, dest, 524288)
         assert zinfo.file_size
 
-    def put(self, archive_name, source: Union[str, IO]):
+    def put(self, archive_name: str, source: Union[str, IO]) -> None:
         compress_type = (
             zipfile.ZIP_DEFLATED
             if guess_compressible(archive_name)
@@ -103,7 +109,7 @@ class ZipArchive(BaseArchive, zipfile.ZipFile):
 
 
 class TarArchive(BaseArchive, tarfile.TarFile):
-    def put(self, archive_name, source: Union[str, IO]):
+    def put(self, archive_name: str, source: Union[str, IO]) -> None:
         with contextlib.ExitStack() as es:
             if isinstance(source, str):
                 size = os.stat(source).st_size
@@ -119,7 +125,7 @@ class TarArchive(BaseArchive, tarfile.TarFile):
             self.addfile(tarinfo, stream)
 
 
-def open_archive(path: str):
+def open_archive(path: str) -> BaseArchive:
     if path.endswith(".zip"):
         return ZipArchive(path, "w")
     elif path.endswith(".tar"):

--- a/valohai/internals/download.py
+++ b/valohai/internals/download.py
@@ -15,20 +15,21 @@ def download_url(url, path, force_download=False):
             ) from ie
 
         tmp_path = tempfile.NamedTemporaryFile().name
-        print(f"Downloading {url} -> {path}")
+        print(f"Downloading {url} -> {path}")  # noqa
         r = requests.get(url, stream=True)
         r.raise_for_status()
         total = (
             int(r.headers["content-length"]) if "content-length" in r.headers else None
         )
 
-        with tqdm(total=total, unit="iB", unit_scale=True) as t:
-            with open(tmp_path, "wb") as f:
-                for data in r.iter_content(1048576):
-                    t.update(len(data))
-                    f.write(data)
+        with tqdm(total=total, unit="iB", unit_scale=True) as t, open(
+            tmp_path, "wb"
+        ) as f:
+            for data in r.iter_content(1048576):
+                t.update(len(data))
+                f.write(data)
         os.replace(tmp_path, path)
     else:
-        print(f"Using cached {path}")
+        print(f"Using cached {path}")  # noqa
 
     return path

--- a/valohai/internals/download.py
+++ b/valohai/internals/download.py
@@ -3,7 +3,7 @@ import tempfile
 
 
 # TODO: This is close to valohai-local-run. Possibility to merge.
-def download_url(url, path, force_download=False):
+def download_url(url: str, path: str, force_download: bool = False) -> str:
     if not os.path.isfile(path) or force_download:
         try:
             import requests

--- a/valohai/internals/files.py
+++ b/valohai/internals/files.py
@@ -16,7 +16,7 @@ def get_glob_pattern(source: str) -> str:
     return source
 
 
-def expand_globs(sources: Union[str, list], preprocessor: lambda s: s) -> Set[str]:
+def expand_globs(sources: Union[str, list], preprocessor=lambda s: s) -> Set[str]:
     if isinstance(sources, str):
         sources = [sources]
     files_to_compress = set()

--- a/valohai/internals/files.py
+++ b/valohai/internals/files.py
@@ -5,7 +5,7 @@ from stat import S_IREAD, S_IRGRP, S_IROTH
 from typing import Set, Union
 
 
-def set_file_read_only(path: str):
+def set_file_read_only(path: str) -> None:
     os.chmod(path, S_IREAD | S_IRGRP | S_IROTH)
 
 

--- a/valohai/internals/files.py
+++ b/valohai/internals/files.py
@@ -12,7 +12,7 @@ def set_file_read_only(path: str):
 def get_glob_pattern(source: str) -> str:
     # Path is transformed into glob supported pattern. "example" -> "example/*"
     if os.path.isdir(source):
-        source = f"{source.rstrip('/')}/*"
+        return f"{source.rstrip('/')}/*"
     return source
 
 

--- a/valohai/internals/global_state.py
+++ b/valohai/internals/global_state.py
@@ -1,4 +1,6 @@
-input_infos = {}
-parsed_parameters = {}
+from typing import Any, Dict, Optional
+
+input_infos: Dict[str, Any] = {}
+parsed_parameters: Dict[str, Any] = {}
 step_name = ""
-image_name = ""
+image_name: Optional[str] = ""

--- a/valohai/internals/guid.py
+++ b/valohai/internals/guid.py
@@ -4,7 +4,7 @@ import uuid
 _execution_guid = None
 
 
-def get_execution_guid():
+def get_execution_guid() -> str:
     global _execution_guid
     if not _execution_guid:
         _execution_guid = f'{time.strftime("%Y%m%d-%H%M%S")}-{uuid.uuid4().hex[:6]}'

--- a/valohai/internals/input_info.py
+++ b/valohai/internals/input_info.py
@@ -84,3 +84,4 @@ def load_input_info(
                 input_info = InputInfo.from_json_data(input_info_data)
                 global_state.input_infos[name] = input_info
                 return global_state.input_infos[name]
+    return None

--- a/valohai/internals/input_info.py
+++ b/valohai/internals/input_info.py
@@ -26,9 +26,11 @@ class FileInfo:
         self.size = int(size) if size else None
 
     def is_downloaded(self) -> Optional[bool]:
-        return self.path and os.path.isfile(self.path)
+        return bool(self.path and os.path.isfile(self.path))
 
     def download(self, path: str, force_download: bool = False) -> None:
+        if not self.uri:
+            raise ValueError("Can not download file with no URI")
         self.path = download_url(
             self.uri, os.path.join(path, self.name), force_download
         )

--- a/valohai/internals/input_info.py
+++ b/valohai/internals/input_info.py
@@ -10,17 +10,25 @@ from valohai.paths import get_inputs_path
 
 
 class FileInfo:
-    def __init__(self, *, name, uri, path, size, checksums):
+    def __init__(
+        self,
+        *,
+        name: str,
+        uri: Optional[str],
+        path: Optional[str],
+        size: Optional[int],
+        checksums: Optional[dict],
+    ) -> None:
         self.name = str(name)
         self.uri = str(uri) if uri else None
         self.checksums = checksums
         self.path = str(path) if path else None
         self.size = int(size) if size else None
 
-    def is_downloaded(self):
+    def is_downloaded(self) -> Optional[bool]:
         return self.path and os.path.isfile(self.path)
 
-    def download(self, path, force_download: bool = False):
+    def download(self, path: str, force_download: bool = False) -> None:
         self.path = download_url(
             self.uri, os.path.join(path, self.name), force_download
         )
@@ -31,13 +39,13 @@ class InputInfo:
     def __init__(self, files: Iterable[FileInfo]):
         self.files = list(files)
 
-    def is_downloaded(self):
+    def is_downloaded(self) -> bool:
         if not self.files:
             return False
 
         return all(f.is_downloaded() for f in self.files)
 
-    def download(self, path, force_download: bool = False):
+    def download(self, path: str, force_download: bool = False) -> None:
         for f in self.files:
             f.download(path, force_download)
 

--- a/valohai/internals/merge.py
+++ b/valohai/internals/merge.py
@@ -6,6 +6,7 @@ from valohai_yaml.utils.merge import merge_dicts, merge_simple
 
 from valohai.consts import DEFAULT_DOCKER_IMAGE
 
+
 def python_to_yaml_merge_strategy(original: Item, parsed: Item) -> Item:
     """Merging strategy in the valohai-utils AST parser use-case
 
@@ -75,7 +76,7 @@ def _merge_step(original: Step, parsed: Step) -> Step:
         skip_missing_b=True,
     )
 
-    if parsed.image is not None and parsed.image != DEFAULT_DOCKER_IMAGE :
+    if parsed.image is not None and parsed.image != DEFAULT_DOCKER_IMAGE:
         result.image = parsed.image
 
     return result

--- a/valohai/internals/merge.py
+++ b/valohai/internals/merge.py
@@ -1,7 +1,8 @@
 import copy
 
-from valohai_yaml.objs import Config, Step
 from valohai_yaml.objs.base import Item
+from valohai_yaml.objs.config import Config
+from valohai_yaml.objs.step import Step
 from valohai_yaml.utils.merge import merge_dicts, merge_simple
 
 from valohai.consts import DEFAULT_DOCKER_IMAGE

--- a/valohai/internals/parsing.py
+++ b/valohai/internals/parsing.py
@@ -2,7 +2,6 @@ import ast
 from collections import namedtuple
 from typing import List
 
-from valohai.consts import DEFAULT_DOCKER_IMAGE
 
 def is_module_function_call(node, module, function):
     try:
@@ -63,36 +62,35 @@ class PrepareParser(ast.NodeVisitor):
         if hasattr(node, "keywords"):
             for key in node.keywords:
                 if key.arg == "default_parameters":
-                    if (
-                        isinstance(key.value, ast.Name)
-                        and key.value.id in self.assignments
-                    ):
-                        self.parameters = self.assignments[key.value.id]
-                    elif isinstance(key.value, ast.Dict):
-                        self.parameters = ast.literal_eval(key.value)
-                    else:
-                        raise NotImplementedError()
+                    self.process_default_parameters_arg(key)
                 elif key.arg == "default_inputs":
-                    if (
-                        isinstance(key.value, ast.Name)
-                        and key.value.id in self.assignments
-                    ):
-                        self.inputs = {
-                            key: value if isinstance(value, List) else [value]
-                            for key, value in self.assignments[key.value.id].items()
-                        }
-                    elif isinstance(key.value, ast.Dict):
-                        self.inputs = {
-                            key: value if isinstance(value, List) else [value]
-                            for key, value in ast.literal_eval(key.value).items()
-                        }
-                    else:
-                        raise NotImplementedError()
+                    self.process_default_inputs_arg(key)
                 elif key.arg == "step":
                     self.step = ast.literal_eval(key.value)
                 elif key.arg == "image":
                     self.image = ast.literal_eval(key.value)
 
+    def process_default_inputs_arg(self, key):
+        if isinstance(key.value, ast.Name) and key.value.id in self.assignments:
+            self.inputs = {
+                key: value if isinstance(value, List) else [value]
+                for key, value in self.assignments[key.value.id].items()
+            }
+        elif isinstance(key.value, ast.Dict):
+            self.inputs = {
+                key: value if isinstance(value, List) else [value]
+                for key, value in ast.literal_eval(key.value).items()
+            }
+        else:
+            raise NotImplementedError()
+
+    def process_default_parameters_arg(self, key):
+        if isinstance(key.value, ast.Name) and key.value.id in self.assignments:
+            self.parameters = self.assignments[key.value.id]
+        elif isinstance(key.value, ast.Dict):
+            self.parameters = ast.literal_eval(key.value)
+        else:
+            raise NotImplementedError()
 
 
 def parse(source):
@@ -100,4 +98,9 @@ def parse(source):
     parser = PrepareParser()
     parser.visit(tree)
     result = namedtuple("result", ["step", "parameters", "inputs", "image"])
-    return result(step=parser.step, parameters=parser.parameters, inputs=parser.inputs, image=parser.image)
+    return result(
+        step=parser.step,
+        parameters=parser.parameters,
+        inputs=parser.inputs,
+        image=parser.image,
+    )

--- a/valohai/internals/parsing.py
+++ b/valohai/internals/parsing.py
@@ -1,11 +1,11 @@
 import ast
 from collections import namedtuple
-from typing import List
+from typing import Any, Dict, List, Optional
 
 
 def is_module_function_call(node: ast.Call, module: str, function: str) -> bool:
     try:
-        return node.func.attr == function and node.func.value.id == module
+        return node.func.attr == function and node.func.value.id == module  # type: ignore
     except AttributeError:
         return False
 
@@ -39,6 +39,11 @@ class PrepareParser(ast.NodeVisitor):
         valohai.prepare(parameters=get_parameters())
     """
 
+    assignments: Dict[str, Any]  # TODO: embetter type
+    parameters: Dict[str, Any]  # TODO: embetter type
+    inputs: Dict[str, Any]  # TODO: embetter type
+    step: Optional[str]
+
     def __init__(self) -> None:
         self.assignments = {}
         self.parameters = {}
@@ -48,7 +53,7 @@ class PrepareParser(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign) -> None:
         try:
-            self.assignments[node.targets[0].id] = ast.literal_eval(node.value)
+            self.assignments[node.targets[0].id] = ast.literal_eval(node.value)  # type: ignore
         except ValueError:
             # We don't care about assignments that can't be literal_eval():ed
             pass

--- a/valohai/internals/vfs.py
+++ b/valohai/internals/vfs.py
@@ -41,7 +41,7 @@ class FileOnDisk(File):
         self.dir_entry = dir_entry
 
     def open(self):
-        return open(self.path, "rb")
+        return open(self.path, "rb")  # noqa: SIM115
 
     @property
     def name(self) -> str:
@@ -53,7 +53,7 @@ class FileInContainer(File):
 
     def open_concrete(self, delete=True):
         if self._concrete_path and os.path.isfile(self._concrete_path):
-            return open(self._concrete_path)
+            return open(self._concrete_path)  # noqa: SIM115
         tf = tempfile.NamedTemporaryFile(suffix=self.extension, delete=delete)
         self.extract(tf)
         tf.seek(0)
@@ -62,7 +62,7 @@ class FileInContainer(File):
 
     def extract(self, destination: Union[str, IO]):
         if isinstance(destination, str):
-            destination = open(destination, "wb")
+            destination = open(destination, "wb")  # noqa: SIM115
             should_close = True
         else:
             should_close = False

--- a/valohai/internals/yaml.py
+++ b/valohai/internals/yaml.py
@@ -54,7 +54,7 @@ def generate_config(
     parameters: ParameterDict,
     inputs: InputDict,
 ) -> Config:
-    step = generate_step(
+    step_obj = generate_step(
         relative_source_path=relative_source_path,
         step=step,
         image=image,
@@ -62,7 +62,7 @@ def generate_config(
         inputs=inputs,
     )
     config = Config()
-    config.steps[step.name] = step
+    config.steps[step_obj.name] = step_obj
     return config
 
 

--- a/valohai/internals/yaml.py
+++ b/valohai/internals/yaml.py
@@ -1,8 +1,10 @@
 import os
 from typing import Any, Dict
 
-from valohai_yaml.objs import Config, Parameter, Step
+from valohai_yaml.objs.config import Config
 from valohai_yaml.objs.input import Input, KeepDirectories
+from valohai_yaml.objs.parameter import Parameter
+from valohai_yaml.objs.step import Step
 
 from valohai.consts import DEFAULT_DOCKER_IMAGE
 from valohai.internals.parsing import parse
@@ -17,7 +19,7 @@ def generate_step(
     step: str,
     image: str,
     parameters: ParameterDict,
-    inputs: InputDict
+    inputs: InputDict,
 ) -> Step:
     config_step = Step(
         name=step,
@@ -50,7 +52,7 @@ def generate_config(
     step: str,
     image: str,
     parameters: ParameterDict,
-    inputs: InputDict
+    inputs: InputDict,
 ) -> Config:
     step = generate_step(
         relative_source_path=relative_source_path,
@@ -85,7 +87,7 @@ def get_source_relative_path(source_path: str, config_path: str) -> str:
     return os.path.join(relative_source_dir, os.path.basename(source_path))
 
 
-def parse_config_from_source(source_path: str, config_path: str):
+def parse_config_from_source(source_path: str, config_path: str) -> Config:
     with open(source_path) as source_file:
         parsed = parse(source_file.read())
         if not parsed.step:

--- a/valohai/internals/yaml.py
+++ b/valohai/internals/yaml.py
@@ -4,9 +4,8 @@ from typing import Any, Dict
 from valohai_yaml.objs import Config, Parameter, Step
 from valohai_yaml.objs.input import Input, KeepDirectories
 
-from valohai.internals.parsing import parse
-
 from valohai.consts import DEFAULT_DOCKER_IMAGE
+from valohai.internals.parsing import parse
 
 ParameterDict = Dict[str, Any]
 InputDict = Dict[str, str]
@@ -25,7 +24,7 @@ def generate_step(
         image=image,
         command=[
             "pip install -r requirements.txt",
-            "python %s {parameters}" % relative_source_path
+            "python %s {parameters}" % relative_source_path,
         ],
     )
 

--- a/valohai/metadata.py
+++ b/valohai/metadata.py
@@ -71,7 +71,7 @@ class Logger:
         """
         if self.partial_logs:
             # Start with \n, ensuring JSON prints on it's own line
-            print(f"\n{json.dumps(self.partial_logs, default=str)}")
+            print(f"\n{json.dumps(self.partial_logs, default=str)}")  # noqa
             self.partial_logs.clear()
 
     def _serialize(self, name, value):

--- a/valohai/metadata.py
+++ b/valohai/metadata.py
@@ -1,10 +1,12 @@
 import json
-from typing import Any
+from typing import Any, Dict
 
 _supported_types = [int, float]
 
 
 class Logger:
+    partial_logs: Dict[str, Any]
+
     def __init__(self) -> None:
         self.partial_logs = {}
 

--- a/valohai/metadata.py
+++ b/valohai/metadata.py
@@ -71,7 +71,7 @@ class Logger:
         """
         if self.partial_logs:
             # Start with \n, ensuring JSON prints on it's own line
-            print(f'\n{json.dumps(self.partial_logs, default=str)}')
+            print(f"\n{json.dumps(self.partial_logs, default=str)}")
             self.partial_logs.clear()
 
     def _serialize(self, name, value):

--- a/valohai/metadata.py
+++ b/valohai/metadata.py
@@ -1,20 +1,21 @@
 import json
+from typing import Any
 
 _supported_types = [int, float]
 
 
 class Logger:
-    def __init__(self):
+    def __init__(self) -> None:
         self.partial_logs = {}
 
-    def __enter__(self):
+    def __enter__(self) -> "Logger":
         self.partial_logs = {}
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type, value, traceback) -> None:
         self.flush()
 
-    def log(self, *args, **kwargs):
+    def log(self, *args, **kwargs) -> None:
         """Log a single name/value pair to be flushed into standard output later as batch.
 
         For a repeating iteration like a machine learning training loop, Valohai expects
@@ -54,7 +55,7 @@ class Logger:
         for key, value in kwargs.items():
             self._serialize(key, value)
 
-    def flush(self):
+    def flush(self) -> None:
         """Flush all the partial logs into standard as a batch.
 
         For a repeating iteration like a machine learning training loop, Valohai expects
@@ -74,7 +75,7 @@ class Logger:
             print(f"\n{json.dumps(self.partial_logs, default=str)}")  # noqa
             self.partial_logs.clear()
 
-    def _serialize(self, name, value):
+    def _serialize(self, name: str, value: Any) -> None:
         self.partial_logs.update({str(name): value})
 
 

--- a/valohai/outputs.py
+++ b/valohai/outputs.py
@@ -14,7 +14,7 @@ from valohai.paths import get_outputs_path
 
 
 class Output:
-    def __init__(self, name: str = ""):
+    def __init__(self, name: str = "") -> None:
         self.name = str(name)
 
     def path(self, filename: str, makedirs: bool = True) -> str:
@@ -52,7 +52,7 @@ class Output:
 
         return path
 
-    def live_upload(self, filename: str):
+    def live_upload(self, filename: str) -> None:
         for file_path in glob.glob(get_glob_pattern(self.path(filename))):
             set_file_read_only(file_path)
 

--- a/valohai/outputs.py
+++ b/valohai/outputs.py
@@ -88,7 +88,7 @@ class Output:
         tmp_file = tempfile.NamedTemporaryFile(
             dir=os.path.dirname(target_path), suffix=suffix, delete=False
         )
-        with tmp_file, open_archive(tmp_file.name) as archive:
+        with tmp_file, open_archive(tmp_file.name) as archive:  # type: ignore
             compressed_paths = []
             for file_path in files_to_compress:
                 arc_path = os.path.relpath(file_path, common_prefix)

--- a/valohai/parameters.py
+++ b/valohai/parameters.py
@@ -1,10 +1,9 @@
 from valohai.internals import global_state
-
-from .internals.parameters import load_parameter, supported_types
+from valohai.internals.parameters import load_parameter, supported_types
 
 
 class Parameter:
-    def __init__(self, name: str, default: supported_types = None):
+    def __init__(self, name: str, default: supported_types = None) -> None:
         self.name = str(name)
         self.default = default
 

--- a/valohai/paths.py
+++ b/valohai/paths.py
@@ -28,7 +28,7 @@ def get_inputs_path(input_name: Optional[str] = None) -> str:
         )
 
     if input_name:
-        path = os.path.join(path, input_name)
+        return os.path.join(path, input_name)
     return path
 
 

--- a/valohai/utils.py
+++ b/valohai/utils.py
@@ -16,7 +16,7 @@ def prepare(
     default_parameters: Optional[dict] = None,
     default_inputs: Optional[dict] = None,
     image: str = None,
-):
+) -> None:
     """Define the name of the step and it's required inputs, parameters and Docker image
 
     Has dual purpose:

--- a/valohai/utils.py
+++ b/valohai/utils.py
@@ -2,7 +2,7 @@ import argparse
 import glob
 import os
 import sys
-from typing import List
+from typing import List, Optional
 
 from valohai.config import is_running_in_valohai
 from valohai.internals import global_state
@@ -13,8 +13,8 @@ from valohai.parameters import Parameter
 def prepare(
     *,
     step: str,
-    default_parameters: dict = {},
-    default_inputs: dict = {},
+    default_parameters: Optional[dict] = None,
+    default_inputs: Optional[dict] = None,
     image: str = None,
 ):
     """Define the name of the step and it's required inputs, parameters and Docker image
@@ -29,6 +29,10 @@ def prepare(
     :param image: Default docker image
 
     """
+    if default_inputs is None:
+        default_inputs = {}
+    if default_parameters is None:
+        default_parameters = {}
     global_state.step_name = step
     global_state.image_name = image
 

--- a/valohai/utils.py
+++ b/valohai/utils.py
@@ -10,7 +10,13 @@ from valohai.internals.input_info import FileInfo, InputInfo
 from valohai.parameters import Parameter
 
 
-def prepare(*, step: str, default_parameters: dict = {}, default_inputs: dict = {}, image: str = None):
+def prepare(
+    *,
+    step: str,
+    default_parameters: dict = {},
+    default_inputs: dict = {},
+    image: str = None,
+):
     """Define the name of the step and it's required inputs, parameters and Docker image
 
     Has dual purpose:

--- a/valohai/utils.py
+++ b/valohai/utils.py
@@ -50,7 +50,7 @@ def prepare(
     _load_parameters(known_args, list(default_parameters.keys()))
 
     for unknown in unknown_args:
-        print(
+        print(  # noqa
             f"Warning: Unexpected command-line argument {unknown} found.",
             file=sys.stderr,
         )

--- a/valohai/yaml.py
+++ b/valohai/yaml.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 import yaml
-from valohai_yaml.objs import Config
+from valohai_yaml.objs.config import Config
 
 # https://stackoverflow.com/questions/42518067/how-to-use-ordereddict-as-an-input-in-yaml-dump-or-yaml-safe-dump
 yaml.add_representer(
@@ -12,7 +12,7 @@ yaml.add_representer(
 )
 
 
-def config_to_yaml(config: Config):
+def config_to_yaml(config: Config) -> str:
     """Serialize Valohai Config to YAML
 
     :param config: valohai_yaml.objs.Config object


### PR DESCRIPTION
This PR:

* enables Flake8, Black and Isort to be run during CI
* adds some Flake8 plugins that are in use in Papi
* fixes some likely bugs noted by those plugins
* adds some basic type hinting for a better DX
* adds Mypy for better type hinting
* fixes some likely bugs noted by Mypy