### PR TITLE
Expect AttributeError when trying to eval assignments (fixes #43)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,11 @@ setuptools.setup(
     author_email="hait@valohai.com",
     license="MIT",
     packages=setuptools.find_packages(include=("valohai*",)),
-    install_requires=["tqdm", "requests", "valohai-yaml>=0.13.0", "valohai-papi>=0.1.1"],
+    install_requires=[
+        "tqdm",
+        "requests",
+        "valohai-yaml>=0.13.0",
+        "valohai-papi>=0.1.1",
+    ],
     python_requires=">=3.6",
 )

--- a/valohai/internals/parsing.py
+++ b/valohai/internals/parsing.py
@@ -54,7 +54,7 @@ class PrepareParser(ast.NodeVisitor):
     def visit_Assign(self, node: ast.Assign) -> None:
         try:
             self.assignments[node.targets[0].id] = ast.literal_eval(node.value)  # type: ignore
-        except ValueError:
+        except (ValueError, AttributeError):
             # We don't care about assignments that can't be literal_eval():ed
             pass
 


### PR DESCRIPTION
If valohai-utils faces code like...
```
X['Intercept'] = 1.
```
...it can't eval (which is expected). However, it is currently only designed to pass on `ValueError`, but fails on the `AttributeError` that evaling this code raises.

