### PR TITLE
Make inputs optional if the defaults are set empty

### DIFF
--- a/tests/test_yaml/test1.expected.valohai.yaml
+++ b/tests/test_yaml/test1.expected.valohai.yaml
@@ -34,6 +34,8 @@
       - yolol
       - yalala
       optional: false
+    - name: my-optional-input
+      optional: true
 - step:
     name: herpderp
     image: busybox

--- a/tests/test_yaml/test1.py
+++ b/tests/test_yaml/test1.py
@@ -7,7 +7,7 @@ params = {
     "param4": 0.0001,
 }
 
-inputs = {"input1": "asdf", "input2": ["yolol", "yalala"]}
+inputs = {"input1": "asdf", "input2": ["yolol", "yalala"], "my-optional-input": ""}
 
 
 def prepare(a, b):

--- a/valohai/internals/yaml.py
+++ b/valohai/internals/yaml.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from valohai_yaml.objs.config import Config
 from valohai_yaml.objs.input import Input, KeepDirectories
@@ -10,7 +10,7 @@ from valohai.consts import DEFAULT_DOCKER_IMAGE
 from valohai.internals.parsing import parse
 
 ParameterDict = Dict[str, Any]
-InputDict = Dict[str, str]
+InputDict = Dict[str, List[str]]
 
 
 def generate_step(

--- a/valohai/internals/yaml.py
+++ b/valohai/internals/yaml.py
@@ -40,8 +40,13 @@ def generate_step(
     for key, value in inputs.items():
         has_wildcards = any("*" in uri for uri in value)
         keep_directories = KeepDirectories.SUFFIX.value if has_wildcards else False
+        empty_default = not value or len(value) == 0 or len(value) == 1 and not value[0]
+
         config_step.inputs[key] = Input(
-            name=key, default=value, keep_directories=keep_directories
+            name=key,
+            default=None if empty_default else value,
+            keep_directories=keep_directories,
+            optional=empty_default,
         )
     return config_step
 


### PR DESCRIPTION
Users want to define optional inputs with `valohai-utils`, but currently, it is not supported.

You define an input with `valohai-utils` like this:
```
default_inputs = {
  "my_input": "https://herpderp.com/lol.txt"
}
```

Generated YAML:
```
- name: my_input
  default:
  - https://herpderp.com/lol.txt
  optional: false
```

This PR introduces support for optional inputs. Just leave the value empty:
```
default_inputs = {
  "my_input": ""
}
```

Generated YAML:
```
- name: my_input
  optional: true
```
