### PR TITLE
Add wildcard support for paths() and streams() (fixes #54)

### DIFF
--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -11,21 +11,59 @@ def test_get_input_paths(use_test_config_dir):
         .path(default="unused_default")
         .endswith("single_image/Example.jpg")
     )
+
+    assert valohai.inputs("single_image").path("Example.jpg").endswith("single_image/Example.jpg")
+    assert valohai.inputs("single_image").path("*.jpg").endswith("single_image/Example.jpg")
+    assert valohai.inputs("single_image").path("E*").endswith("single_image/Example.jpg")
+    assert valohai.inputs("single_image").path("*").endswith("single_image/Example.jpg")
+    assert not valohai.inputs("single_image").path("notbefound*")
+    assert next(valohai.inputs("single_image").paths("Example.jpg")).endswith("single_image/Example.jpg")
+    assert next(valohai.inputs("single_image").paths("*.jpg")).endswith("single_image/Example.jpg")
+    assert next(valohai.inputs("single_image").paths("E*")).endswith("single_image/Example.jpg")
+    assert next(valohai.inputs("single_image").paths("*")).endswith("single_image/Example.jpg")
+    assert len(list(valohai.inputs("single_image").paths("notbefound*"))) == 0
+
     assert not valohai.inputs("nonono").path()
     assert valohai.inputs("nonono").path(default="default_123") == "default_123"
     assert os.path.exists(valohai.inputs("input_with_archive").path())
+    assert len(list(valohai.inputs("input_with_archive").paths())) == 5
+    assert len(list(valohai.inputs("input_with_archive").paths("**/*.txt"))) == 2
+    assert len(list(valohai.inputs("input_with_archive").paths("**/a*.jpg"))) == 1
+    assert next(valohai.inputs("input_with_archive").paths("**/a*.jpg")).endswith("blerp/blonk/asdf.jpg")
+    assert next(valohai.inputs("input_with_archive").paths("**/asdf.jpg")).endswith("blerp/blonk/asdf.jpg")
+    assert next(valohai.inputs("input_with_archive").paths("blerp/blonk/asdf.jpg")).endswith("blerp/blonk/asdf.jpg")
+
     for path in valohai.inputs("input_with_archive").paths():
         assert os.path.exists(path)
-    assert len(list(valohai.inputs("input_with_archive").paths())) == 4
+
+    assert len(list(valohai.inputs("input_with_archive").paths())) == 5
+
+    for path in valohai.inputs("input_with_archive").paths("**/*.jpg"):
+        assert os.path.exists(path)
+
+    assert next(valohai.inputs("images_in_subdirs").paths("hello/label1/hello/*.jpg")).endswith("label1/hello/foo.jpg")
+    assert next(valohai.inputs("images_in_subdirs").paths("hello/label2/hello/*.jpg")).endswith("label2/hello/foo.jpg")
+    assert len(list(valohai.inputs("images_in_subdirs").paths("hello/**/hello/*.jpg"))) == 2
+    assert len(list(valohai.inputs("images_in_subdirs").paths("hello/**/*.jpg"))) == 2
+    assert len(list(valohai.inputs("images_in_subdirs").paths("**/*.jpg"))) == 2
+    for path in valohai.inputs("images_in_subdirs").paths("**/*.jpg"):
+        assert os.path.exists(path)
+
 
 
 def test_get_input_streams(use_test_config_dir):
     assert valohai.inputs("single_image").stream().read(10000)
-    assert len(list(valohai.inputs("input_with_archive").streams())) == 4
+    assert len(list(valohai.inputs("input_with_archive").streams())) == 5
+
     for stream in valohai.inputs("input_with_archive").streams():
         assert stream.read(10000)
     assert valohai.inputs("single_image").stream().read()
     assert not valohai.inputs("nonono").stream()
+    assert len(list(valohai.inputs("images_in_subdirs").streams("hello/**/hello/*.jpg"))) == 2
+    assert len(list(valohai.inputs("images_in_subdirs").streams("hello/**/*.jpg"))) == 2
+    assert len(list(valohai.inputs("images_in_subdirs").streams("**/*.jpg"))) == 2
+    for stream in valohai.inputs("images_in_subdirs").streams("**/*.jpg"):
+        assert stream.read(10000)
 
 
 def test_zip_no_mangling(use_test_config_dir):
@@ -35,5 +73,7 @@ def test_zip_no_mangling(use_test_config_dir):
         "2world.txt",
         "blerp/3katt.txt",
         "blerp/blonk/4blöf.txt",
+        "blerp/blonk/asdf.jpg",
     ):
         assert any(p.endswith(suffix) for p in paths)
+

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -12,15 +12,33 @@ def test_get_input_paths(use_test_config_dir):
         .endswith("single_image/Example.jpg")
     )
 
-    assert valohai.inputs("single_image").path("Example.jpg").endswith("single_image/Example.jpg")
-    assert valohai.inputs("single_image").path("*.jpg").endswith("single_image/Example.jpg")
-    assert valohai.inputs("single_image").path("E*").endswith("single_image/Example.jpg")
+    assert (
+        valohai.inputs("single_image")
+        .path("Example.jpg")
+        .endswith("single_image/Example.jpg")
+    )
+    assert (
+        valohai.inputs("single_image")
+        .path("*.jpg")
+        .endswith("single_image/Example.jpg")
+    )
+    assert (
+        valohai.inputs("single_image").path("E*").endswith("single_image/Example.jpg")
+    )
     assert valohai.inputs("single_image").path("*").endswith("single_image/Example.jpg")
     assert not valohai.inputs("single_image").path("notbefound*")
-    assert next(valohai.inputs("single_image").paths("Example.jpg")).endswith("single_image/Example.jpg")
-    assert next(valohai.inputs("single_image").paths("*.jpg")).endswith("single_image/Example.jpg")
-    assert next(valohai.inputs("single_image").paths("E*")).endswith("single_image/Example.jpg")
-    assert next(valohai.inputs("single_image").paths("*")).endswith("single_image/Example.jpg")
+    assert next(valohai.inputs("single_image").paths("Example.jpg")).endswith(
+        "single_image/Example.jpg"
+    )
+    assert next(valohai.inputs("single_image").paths("*.jpg")).endswith(
+        "single_image/Example.jpg"
+    )
+    assert next(valohai.inputs("single_image").paths("E*")).endswith(
+        "single_image/Example.jpg"
+    )
+    assert next(valohai.inputs("single_image").paths("*")).endswith(
+        "single_image/Example.jpg"
+    )
     assert len(list(valohai.inputs("single_image").paths("notbefound*"))) == 0
 
     assert not valohai.inputs("nonono").path()
@@ -29,9 +47,15 @@ def test_get_input_paths(use_test_config_dir):
     assert len(list(valohai.inputs("input_with_archive").paths())) == 5
     assert len(list(valohai.inputs("input_with_archive").paths("**/*.txt"))) == 2
     assert len(list(valohai.inputs("input_with_archive").paths("**/a*.jpg"))) == 1
-    assert next(valohai.inputs("input_with_archive").paths("**/a*.jpg")).endswith("blerp/blonk/asdf.jpg")
-    assert next(valohai.inputs("input_with_archive").paths("**/asdf.jpg")).endswith("blerp/blonk/asdf.jpg")
-    assert next(valohai.inputs("input_with_archive").paths("blerp/blonk/asdf.jpg")).endswith("blerp/blonk/asdf.jpg")
+    assert next(valohai.inputs("input_with_archive").paths("**/a*.jpg")).endswith(
+        "blerp/blonk/asdf.jpg"
+    )
+    assert next(valohai.inputs("input_with_archive").paths("**/asdf.jpg")).endswith(
+        "blerp/blonk/asdf.jpg"
+    )
+    assert next(
+        valohai.inputs("input_with_archive").paths("blerp/blonk/asdf.jpg")
+    ).endswith("blerp/blonk/asdf.jpg")
 
     for path in valohai.inputs("input_with_archive").paths():
         assert os.path.exists(path)
@@ -41,14 +65,20 @@ def test_get_input_paths(use_test_config_dir):
     for path in valohai.inputs("input_with_archive").paths("**/*.jpg"):
         assert os.path.exists(path)
 
-    assert next(valohai.inputs("images_in_subdirs").paths("hello/label1/hello/*.jpg")).endswith("label1/hello/foo.jpg")
-    assert next(valohai.inputs("images_in_subdirs").paths("hello/label2/hello/*.jpg")).endswith("label2/hello/foo.jpg")
-    assert len(list(valohai.inputs("images_in_subdirs").paths("hello/**/hello/*.jpg"))) == 2
+    assert next(
+        valohai.inputs("images_in_subdirs").paths("hello/label1/hello/*.jpg")
+    ).endswith("label1/hello/foo.jpg")
+    assert next(
+        valohai.inputs("images_in_subdirs").paths("hello/label2/hello/*.jpg")
+    ).endswith("label2/hello/foo.jpg")
+    assert (
+        len(list(valohai.inputs("images_in_subdirs").paths("hello/**/hello/*.jpg")))
+        == 2
+    )
     assert len(list(valohai.inputs("images_in_subdirs").paths("hello/**/*.jpg"))) == 2
     assert len(list(valohai.inputs("images_in_subdirs").paths("**/*.jpg"))) == 2
     for path in valohai.inputs("images_in_subdirs").paths("**/*.jpg"):
         assert os.path.exists(path)
-
 
 
 def test_get_input_streams(use_test_config_dir):
@@ -59,7 +89,10 @@ def test_get_input_streams(use_test_config_dir):
         assert stream.read(10000)
     assert valohai.inputs("single_image").stream().read()
     assert not valohai.inputs("nonono").stream()
-    assert len(list(valohai.inputs("images_in_subdirs").streams("hello/**/hello/*.jpg"))) == 2
+    assert (
+        len(list(valohai.inputs("images_in_subdirs").streams("hello/**/hello/*.jpg")))
+        == 2
+    )
     assert len(list(valohai.inputs("images_in_subdirs").streams("hello/**/*.jpg"))) == 2
     assert len(list(valohai.inputs("images_in_subdirs").streams("**/*.jpg"))) == 2
     for stream in valohai.inputs("images_in_subdirs").streams("**/*.jpg"):
@@ -76,4 +109,3 @@ def test_zip_no_mangling(use_test_config_dir):
         "blerp/blonk/asdf.jpg",
     ):
         assert any(p.endswith(suffix) for p in paths)
-

--- a/tests/valohai_test_environment.py
+++ b/tests/valohai_test_environment.py
@@ -24,6 +24,14 @@ class ValohaiTestEnvironment:
         )
         (self.config_path / "inputs.json").write_text(json.dumps(self.get_inputs()))
 
+        sub_dir = os.path.join(self.inputs_path, "images_in_subdirs")
+        os.makedirs(os.path.join(sub_dir, "hello", "label1", "hello"))
+        os.makedirs(os.path.join(sub_dir, "hello", "label2", "hello"))
+        with open(os.path.join(sub_dir, "hello", "label1", "hello", "foo.jpg"), "wb") as f:
+            f.write(os.urandom(1024))
+        with open(os.path.join(sub_dir, "hello", "label2", "hello", "foo.jpg"), "wb") as f:
+            f.write(os.urandom(1024))
+
         zip_dir = os.path.join(self.inputs_path, "input_with_archive")
         os.makedirs(zip_dir)
         zip_path = os.path.join(zip_dir, "archive.zip")
@@ -35,6 +43,8 @@ class ValohaiTestEnvironment:
             zf.writestr("blerp/3katt.txt", b"Johannes")
             zf.writestr(zipfile.ZipInfo("blerp/blonk/"), "")
             zf.writestr("blerp/blonk/4blöf.txt", b"Teline")
+            zf.writestr("blerp/blonk/asdf.jpg", b"Keijo")
+
 
     def get_inputs(self):
         return {
@@ -56,18 +66,18 @@ class ValohaiTestEnvironment:
             "images_in_subdirs": {
                 "files": [
                     {
-                        "name": "label1/Example.jpg",
-                        "path": "%s/images_in_subdirs/label1/Example.jpg"
-                        % self.inputs_path,
-                        "size": 27661,
-                        "uri": "https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg",
+                        "checksums": {},
+                        "name": "hello/label1/hello/foo.jpg",
+                        "path": "%s/images_in_subdirs/hello/label1/hello/foo.jpg" % self.inputs_path,
+                        "size": 1024,
+                        "uri": "",
                     },
                     {
-                        "name": "label2/Example.jpg",
-                        "path": "%s/images_in_subdirs/label2/Example.jpg"
-                        % self.inputs_path,
-                        "size": 27661,
-                        "uri": "https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg",
+                        "checksums": {},
+                        "name": "hello/label2/hello/foo.jpg",
+                        "path": "%s/images_in_subdirs/hello/label2/hello/foo.jpg" % self.inputs_path,
+                        "size": 1024,
+                        "uri": "",
                     },
                 ]
             },

--- a/tests/valohai_test_environment.py
+++ b/tests/valohai_test_environment.py
@@ -27,9 +27,13 @@ class ValohaiTestEnvironment:
         sub_dir = os.path.join(self.inputs_path, "images_in_subdirs")
         os.makedirs(os.path.join(sub_dir, "hello", "label1", "hello"))
         os.makedirs(os.path.join(sub_dir, "hello", "label2", "hello"))
-        with open(os.path.join(sub_dir, "hello", "label1", "hello", "foo.jpg"), "wb") as f:
+        with open(
+            os.path.join(sub_dir, "hello", "label1", "hello", "foo.jpg"), "wb"
+        ) as f:
             f.write(os.urandom(1024))
-        with open(os.path.join(sub_dir, "hello", "label2", "hello", "foo.jpg"), "wb") as f:
+        with open(
+            os.path.join(sub_dir, "hello", "label2", "hello", "foo.jpg"), "wb"
+        ) as f:
             f.write(os.urandom(1024))
 
         zip_dir = os.path.join(self.inputs_path, "input_with_archive")
@@ -44,7 +48,6 @@ class ValohaiTestEnvironment:
             zf.writestr(zipfile.ZipInfo("blerp/blonk/"), "")
             zf.writestr("blerp/blonk/4blöf.txt", b"Teline")
             zf.writestr("blerp/blonk/asdf.jpg", b"Keijo")
-
 
     def get_inputs(self):
         return {
@@ -68,14 +71,16 @@ class ValohaiTestEnvironment:
                     {
                         "checksums": {},
                         "name": "hello/label1/hello/foo.jpg",
-                        "path": "%s/images_in_subdirs/hello/label1/hello/foo.jpg" % self.inputs_path,
+                        "path": "%s/images_in_subdirs/hello/label1/hello/foo.jpg"
+                        % self.inputs_path,
                         "size": 1024,
                         "uri": "",
                     },
                     {
                         "checksums": {},
                         "name": "hello/label2/hello/foo.jpg",
-                        "path": "%s/images_in_subdirs/hello/label2/hello/foo.jpg" % self.inputs_path,
+                        "path": "%s/images_in_subdirs/hello/label2/hello/foo.jpg"
+                        % self.inputs_path,
                         "size": 1024,
                         "uri": "",
                     },

--- a/valohai/inputs.py
+++ b/valohai/inputs.py
@@ -31,7 +31,9 @@ class Input:
         :return: List of file system paths for all the files for this input.
         """
 
-        fs = self._get_input_vfs(process_archives=process_archives, force_download=force_download)
+        fs = self._get_input_vfs(
+            process_archives=process_archives, force_download=force_download
+        )
         files = fs.filter(path_filter) if path_filter else fs.files
 
         found_file = False
@@ -72,7 +74,7 @@ class Input:
         input_paths = self.paths(
             path_filter=path_filter,
             process_archives=process_archives,
-            force_download=force_download
+            force_download=force_download,
         )
         return next(input_paths, default)
 
@@ -80,7 +82,7 @@ class Input:
         self,
         path_filter: Optional[str] = None,
         process_archives: bool = True,
-        force_download: bool = False
+        force_download: bool = False,
     ) -> Iterator[IO]:
         """Get file streams to all files for a given input name.
 
@@ -96,7 +98,9 @@ class Input:
         :return: Iterable for all the IO streams of files for this input.
         """
 
-        fs = self._get_input_vfs(process_archives=process_archives, force_download=force_download)
+        fs = self._get_input_vfs(
+            process_archives=process_archives, force_download=force_download
+        )
         files = fs.filter(path_filter) if path_filter else fs.files
 
         for file in files:
@@ -106,7 +110,7 @@ class Input:
         self,
         path_filter: Optional[str] = None,
         process_archives: bool = True,
-        force_download: bool = False
+        force_download: bool = False,
     ) -> Optional[IO]:
         """Get a stream for to a file for a given input name.
 
@@ -125,7 +129,7 @@ class Input:
         streams = self.streams(
             path_filter=path_filter,
             process_archives=process_archives,
-            force_download=force_download
+            force_download=force_download,
         )
         return next(streams, None)
 

--- a/valohai/inputs.py
+++ b/valohai/inputs.py
@@ -12,6 +12,7 @@ class Input:
 
     def paths(
         self,
+        path_filter: Optional[str] = None,
         default: Optional[Iterable[str]] = None,
         process_archives: bool = True,
         force_download: bool = False,
@@ -23,16 +24,18 @@ class Input:
 
         See streams() or path() for alternatives.
 
+        :param path_filter: Filter the results with wildcards. For example: "myfile.txt" or "myfolder/*.txt".
         :param default: Default fallback paths.
         :param process_archives: When facing an archive file, is it unpacked to several paths or returned as is
         :param force_download: Force re-download of file(s) even when they are cached already.
         :return: List of file system paths for all the files for this input.
         """
 
+        fs = self._get_input_vfs(process_archives=process_archives, force_download=force_download)
+        files = fs.filter(path_filter) if path_filter else fs.files
+
         found_file = False
-        for file in self._get_input_vfs(
-            process_archives=process_archives, force_download=force_download
-        ).files:
+        for file in files:
             if isinstance(file, vfs.FileInContainer):
                 yield file.open_concrete(delete=False).name
                 found_file = True
@@ -47,6 +50,7 @@ class Input:
 
     def path(
         self,
+        path_filter: Optional[str] = None,
         default: Optional[str] = None,
         process_archives: bool = True,
         force_download: bool = False,
@@ -59,18 +63,24 @@ class Input:
 
         See stream() or paths() for an alternative.
 
+        :param path_filter: Filter the results with wildcards. For example: "myfile.txt" or "myfolder/*.txt".
         :param process_archives: When facing an archive file, is it unpacked or returned as is
         :param default: Default fallback path.
         :param force_download: Force re-download of file(s) even when they are cached already.
         :return: File system path to a file for this input.
         """
         input_paths = self.paths(
-            process_archives=process_archives, force_download=force_download
+            path_filter=path_filter,
+            process_archives=process_archives,
+            force_download=force_download
         )
         return next(input_paths, default)
 
     def streams(
-        self, process_archives: bool = True, force_download: bool = False
+        self,
+        path_filter: Optional[str] = None,
+        process_archives: bool = True,
+        force_download: bool = False
     ) -> Iterator[IO]:
         """Get file streams to all files for a given input name.
 
@@ -80,17 +90,23 @@ class Input:
 
         See stream() or paths() for an alternative.
 
+        :param path_filter: Filter the results with wildcards. For example: "myfile.txt" or "myfolder/*.txt".
         :param process_archives: When facing an archive file, is it unpacked or returned as is
         :param force_download: Force re-download of file(s) even when they are cached already.
         :return: Iterable for all the IO streams of files for this input.
         """
-        for file in self._get_input_vfs(
-            process_archives=process_archives, force_download=force_download
-        ).files:
+
+        fs = self._get_input_vfs(process_archives=process_archives, force_download=force_download)
+        files = fs.filter(path_filter) if path_filter else fs.files
+
+        for file in files:
             yield file.open()
 
     def stream(
-        self, process_archives: bool = True, force_download: bool = False
+        self,
+        path_filter: Optional[str] = None,
+        process_archives: bool = True,
+        force_download: bool = False
     ) -> Optional[IO]:
         """Get a stream for to a file for a given input name.
 
@@ -100,13 +116,16 @@ class Input:
 
         See path() or streams() for an alternative.
 
+        :param path_filter: Filter the results with wildcards. For example: "myfile.txt" or "myfolder/*.txt".
         :param process_archives: When facing an archive file, is it unpacked or returned as is
         :param force_download: Force re-download of file(s) even when they are cached already.
         :return: IO stream to a file for this input.
         """
 
         streams = self.streams(
-            process_archives=process_archives, force_download=force_download
+            path_filter=path_filter,
+            process_archives=process_archives,
+            force_download=force_download
         )
         return next(streams, None)
 

--- a/valohai/internals/vfs.py
+++ b/valohai/internals/vfs.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import shutil
 import tempfile
+import re
 from contextlib import ExitStack
 from tarfile import TarFile, TarInfo
 from typing import IO, List, Optional, Union
@@ -194,6 +195,10 @@ class VFS:
 
     def __exit__(self, *exc_details) -> None:
         self.exit_stack.__exit__(*exc_details)
+
+    def filter(self, path: str) -> List[File]:
+        pattern = re.compile(path.replace("**", "*").replace("*", ".*"))  # support for both * and ** notation
+        return [f for f in self.files if re.match(pattern, f.name)]
 
 
 def add_disk_file(

--- a/valohai/internals/vfs.py
+++ b/valohai/internals/vfs.py
@@ -1,8 +1,8 @@
 import hashlib
 import os
+import re
 import shutil
 import tempfile
-import re
 from contextlib import ExitStack
 from tarfile import TarFile, TarInfo
 from typing import IO, List, Optional, Union
@@ -197,7 +197,9 @@ class VFS:
         self.exit_stack.__exit__(*exc_details)
 
     def filter(self, path: str) -> List[File]:
-        pattern = re.compile(path.replace("**", "*").replace("*", ".*"))  # support for both * and ** notation
+        pattern = re.compile(
+            path.replace("**", "*").replace("*", ".*")
+        )  # support for both * and ** notation
         return [f for f in self.files if re.match(pattern, f.name)]
 
 


### PR DESCRIPTION
**What**

For a single Valohai input, we have `.path()` `.paths()` `.stream()` `.streams()`.

This PR introduces a new parameter `filter_path`, which allows filtering a subset of all the files of the input, based on their file path. Wildcards are supported for both single and double notation.

Example: `valohai.inputs("myinput").paths("folder/**/foo/*.jpg")`

**Why**

If your input has multiple files, but you just want one (or subset).

Before this PR:
```
import fnmatch
for path in fnmatch.filter(valohai.inputs("myinput").paths(), "weights.pb"):
  print(path)
```

After this PR:
```
path = valohai.inputs("myinput").path("weights.pb"):
```

Also supports stuff like:
```
for image_path in valohai.inputs("myinput").paths("folder/**/foo/*.jpg"):
  print(image_path)
```