### PR TITLE
Support notebooks in YAML generator (fixes #61)

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -8,7 +8,7 @@ from .utils import get_parsing_tests
 def read_test_data():
     """
     Expected files (tests/test_parsing):
-        mytest.py -- Python file calling valohai.prepare()
+        mytest.py -- Python (or .ipynb) file calling valohai.prepare()
         mytest.inputs.json -- Expected parsed inputs
         mytest.parameters.json -- Expected parsed parameters
         mytest.step.json -- Expected parsed step

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -16,7 +16,8 @@ from valohai.yaml import config_to_yaml
 )
 def test_yaml_update_from_source(tmpdir, original_yaml, source_python, expected_yaml):
     yaml_path = os.path.join(tmpdir, "valohai.yaml")
-    source_path = os.path.join(tmpdir, "test.py")
+    filename, file_extension = os.path.splitext(source_python)
+    source_path = os.path.join(tmpdir, f"test{file_extension}")
 
     # Build repository with test.py and valohai.yaml
     if os.path.isfile(original_yaml):

--- a/tests/test_yaml/test6.expected.valohai.yaml
+++ b/tests/test_yaml/test6.expected.valohai.yaml
@@ -1,0 +1,21 @@
+- step:
+    name: train
+    image: valohai/pypermill
+    command:
+    - pip install -r requirements.txt
+    - papermill -k python3 -f /valohai/config/parameters.yaml /valohai/repository/./test.ipynb
+      /valohai/outputs/test.ipynb
+    parameters:
+    - name: iterations
+      default: 500
+      multiple-separator: ','
+      optional: false
+      type: integer
+    - name: learning-rate
+      default: 0.001
+      multiple-separator: ','
+      optional: false
+      type: float
+    inputs:
+    - name: my-optional-input
+      optional: true

--- a/tests/test_yaml/test6.ipynb
+++ b/tests/test_yaml/test6.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import valohai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = {\n",
+    "    \"iterations\": 500,\n",
+    "    \"learning-rate\": 0.001,\n",
+    "}\n",
+    "\n",
+    "inputs = {\n",
+    "    \"my-optional-input\": \"\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valohai.prepare(step=\"train\", default_parameters=params, default_inputs=inputs, image=\"valohai/pypermill\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import sleep\n",
+    "import json\n",
+    "\n",
+    "for i in range(valohai.parameters(\"iterations\").value):\n",
+    "    print(json.dumps({'accuracy': round(0.5+(i/126.4), 3), 'loss': round((50-i)*(50-i)/100.1, 3)}))\n",
+    "    sleep(0.33)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_yaml/test7.expected.valohai.yaml
+++ b/tests/test_yaml/test7.expected.valohai.yaml
@@ -1,0 +1,34 @@
+- step:
+    name: re-train
+    image: valohai/pypermill
+    command:
+    - pip install -r requirements.txt
+    - papermill -k python3 -f /valohai/config/parameters.yaml /valohai/repository/./test.ipynb
+      /valohai/outputs/test.ipynb
+    parameters:
+    - name: epochs
+      default: 500
+      multiple-separator: ','
+      optional: false
+      type: integer
+    - name: learning-rate
+      default: 0.001
+      multiple-separator: ','
+      optional: false
+      type: float
+    - name: flaggy
+      default: true
+      multiple-separator: ','
+      type: flag
+    - name: stringy
+      default: holla
+      multiple-separator: ','
+      optional: false
+      type: string
+    inputs:
+    - name: my-image
+      default:
+      - https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg
+      optional: false
+    - name: my-optional-input
+      optional: true

--- a/tests/test_yaml/test7.ipynb
+++ b/tests/test_yaml/test7.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90cc2c56-daa8-45fc-b7bf-8e149f79d8b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import valohai\n",
+    "\n",
+    "params = {\n",
+    "    \"epochs\": 500,\n",
+    "    \"learning-rate\": 0.001,\n",
+    "    \"flaggy\": True,\n",
+    "    \"stringy\": \"holla\",\n",
+    "}\n",
+    "\n",
+    "inputs = {\n",
+    "    \"my-image\": \"https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg\",\n",
+    "    \"my-optional-input\": \"\",\n",
+    "}\n",
+    "\n",
+    "valohai.prepare(\n",
+    "    step=\"re-train\", \n",
+    "    default_parameters=params, \n",
+    "    default_inputs=inputs, \n",
+    "    image=\"valohai/pypermill\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,7 +43,9 @@ def read_yaml_test_data(root_path):
 
     """
     test_data = []
-    for source_path in glob.glob(f"{root_path}/*.py") + glob.glob(f"{root_path}/*.ipynb"):
+    for source_path in glob.glob(f"{root_path}/*.py") + glob.glob(
+        f"{root_path}/*.ipynb"
+    ):
         dirname = os.path.dirname(source_path)
         name, extension = os.path.splitext(os.path.basename(source_path))
         test_data.append(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -33,7 +33,7 @@ def read_yaml_test_data(root_path):
     Returns a list of test sets. Each set is representing a single YAML updating test case.
 
     Expected in the root_path:
-        mytest.py -- Python file defining a step or a pipeline
+        mytest.py -- Python (or .ipynb) file defining a step or a pipeline
         mytest.original.valohai.yaml -- Original valohai.yaml
         mytest.expected.valohai.yaml -- Expected valohai.yaml after update
         mytest2.py -- Another Python file defining a step or a pipeline
@@ -43,7 +43,7 @@ def read_yaml_test_data(root_path):
 
     """
     test_data = []
-    for source_path in glob.glob(f"{root_path}/*.py"):
+    for source_path in glob.glob(f"{root_path}/*.py") + glob.glob(f"{root_path}/*.ipynb"):
         dirname = os.path.dirname(source_path)
         name, extension = os.path.splitext(os.path.basename(source_path))
         test_data.append(

--- a/valohai/internals/notebooks.py
+++ b/valohai/internals/notebooks.py
@@ -1,8 +1,7 @@
 import json
 import os
 import shlex
-from typing import Union, List
-
+from typing import List, Union
 
 # TODO: This file is a copy-pasta from https://github.com/valohai/jupyhai
 # TODO: DRY between libs
@@ -22,22 +21,24 @@ def parse_ipynb(content_or_str: Union[str, dict]) -> dict:
     else:
         content = content_or_str
     if not isinstance(content, dict):
-        raise ValueError('Ipynb not a dict')
+        raise ValueError("Ipynb not a dict")
     assert isinstance(content, dict)
-    if content.get('type') == 'notebook':
-        content = content['content']
+    if content.get("type") == "notebook":
+        content = content["content"]
 
-    nbformat = content.get('nbformat')
+    nbformat = content.get("nbformat")
     if not isinstance(nbformat, int):
-        raise ValueError('Nbformat value %s invalid' % nbformat)
+        raise ValueError("Nbformat value %s invalid" % nbformat)
     return content
 
 
 def get_notebook_source_code(contents: dict) -> str:
-    source = [cell['source'] for cell in contents['cells'] if cell['cell_type'] == 'code']
+    source = [
+        cell["source"] for cell in contents["cells"] if cell["cell_type"] == "code"
+    ]
 
     # Some notebook versions store it as list of rows already. Some as single string.
-    source = [row if isinstance(row, list) else row.split('\n') for row in source]
+    source = [row if isinstance(row, list) else row.split("\n") for row in source]
 
     # Even when it was a list, the linefeeds are still there.
     source = [row.rstrip() for sublist in source for row in sublist]
@@ -45,17 +46,22 @@ def get_notebook_source_code(contents: dict) -> str:
     # Strip magics like "!pip install tensorflow"
     source = [row for row in source if not row.startswith("!")]
 
-    return '\n'.join(source)
+    return "\n".join(source)
 
 
 def get_notebook_command(notebook_relative_path) -> List[str]:
     notebook_dir, notebook_name = os.path.split(notebook_relative_path)
-    papermill_command = " ".join([
-        "papermill -k python3 -f /valohai/config/parameters.yaml",
-        shlex.quote("/valohai/repository/{}".format(notebook_relative_path.replace(os.sep, "/"))),
-        shlex.quote("/valohai/outputs/{}".format(notebook_name.replace(os.sep, "/"))),
-    ])
-    return [
-        "pip install -r requirements.txt",
-        papermill_command
-    ]
+    papermill_command = " ".join(
+        [
+            "papermill -k python3 -f /valohai/config/parameters.yaml",
+            shlex.quote(
+                "/valohai/repository/{}".format(
+                    notebook_relative_path.replace(os.sep, "/")
+                )
+            ),
+            shlex.quote(
+                "/valohai/outputs/{}".format(notebook_name.replace(os.sep, "/"))
+            ),
+        ]
+    )
+    return ["pip install -r requirements.txt", papermill_command]

--- a/valohai/internals/notebooks.py
+++ b/valohai/internals/notebooks.py
@@ -1,0 +1,61 @@
+import json
+import os
+import shlex
+from typing import Union, List
+
+
+# TODO: This file is a copy-pasta from https://github.com/valohai/jupyhai
+# TODO: DRY between libs
+
+
+def parse_ipynb(content_or_str: Union[str, dict]) -> dict:
+    """
+    "Smartly" parse content that contains a notebook.
+    * If a string, it's first JSON deserialized.
+    * If it's a "wrapped" dict (i.e. contains "type" == "notebook" and "content"), unwraps the content
+    * Asserts the content smells like a notebook ("nbformat")
+    :param content: See above.
+    :return: Notebook data.
+    """
+    if isinstance(content_or_str, str):
+        content = json.loads(content_or_str)
+    else:
+        content = content_or_str
+    if not isinstance(content, dict):
+        raise ValueError('Ipynb not a dict')
+    assert isinstance(content, dict)
+    if content.get('type') == 'notebook':
+        content = content['content']
+
+    nbformat = content.get('nbformat')
+    if not isinstance(nbformat, int):
+        raise ValueError('Nbformat value %s invalid' % nbformat)
+    return content
+
+
+def get_notebook_source_code(contents: dict) -> str:
+    source = [cell['source'] for cell in contents['cells'] if cell['cell_type'] == 'code']
+
+    # Some notebook versions store it as list of rows already. Some as single string.
+    source = [row if isinstance(row, list) else row.split('\n') for row in source]
+
+    # Even when it was a list, the linefeeds are still there.
+    source = [row.rstrip() for sublist in source for row in sublist]
+
+    # Strip magics like "!pip install tensorflow"
+    source = [row for row in source if not row.startswith("!")]
+
+    return '\n'.join(source)
+
+
+def get_notebook_command(notebook_relative_path) -> List[str]:
+    notebook_dir, notebook_name = os.path.split(notebook_relative_path)
+    papermill_command = " ".join([
+        "papermill -k python3 -f /valohai/config/parameters.yaml",
+        shlex.quote("/valohai/repository/{}".format(notebook_relative_path.replace(os.sep, "/"))),
+        shlex.quote("/valohai/outputs/{}".format(notebook_name.replace(os.sep, "/"))),
+    ])
+    return [
+        "pip install -r requirements.txt",
+        papermill_command
+    ]

--- a/valohai/internals/yaml.py
+++ b/valohai/internals/yaml.py
@@ -7,7 +7,11 @@ from valohai_yaml.objs.parameter import Parameter
 from valohai_yaml.objs.step import Step
 
 from valohai.consts import DEFAULT_DOCKER_IMAGE
-from valohai.internals.notebooks import parse_ipynb, get_notebook_source_code, get_notebook_command
+from valohai.internals.notebooks import (
+    get_notebook_command,
+    get_notebook_source_code,
+    parse_ipynb,
+)
 from valohai.internals.parsing import parse
 
 ParameterDict = Dict[str, Any]

--- a/valohai/internals/yaml.py
+++ b/valohai/internals/yaml.py
@@ -7,6 +7,7 @@ from valohai_yaml.objs.parameter import Parameter
 from valohai_yaml.objs.step import Step
 
 from valohai.consts import DEFAULT_DOCKER_IMAGE
+from valohai.internals.notebooks import parse_ipynb, get_notebook_source_code, get_notebook_command
 from valohai.internals.parsing import parse
 
 ParameterDict = Dict[str, Any]
@@ -24,10 +25,7 @@ def generate_step(
     config_step = Step(
         name=step,
         image=image,
-        command=[
-            "pip install -r requirements.txt",
-            "python %s {parameters}" % relative_source_path,
-        ],
+        command=get_command(relative_source_path),
     )
 
     for key, value in parameters.items():
@@ -93,18 +91,17 @@ def get_source_relative_path(source_path: str, config_path: str) -> str:
 
 
 def parse_config_from_source(source_path: str, config_path: str) -> Config:
-    with open(source_path) as source_file:
-        parsed = parse(source_file.read())
-        if not parsed.step:
-            raise ValueError("Source is missing a call to valohai.prepare()")
-        relative_source_path = get_source_relative_path(source_path, config_path)
-        return generate_config(
-            relative_source_path=relative_source_path,
-            step=parsed.step,
-            image=DEFAULT_DOCKER_IMAGE if parsed.image is None else parsed.image,
-            parameters=parsed.parameters,
-            inputs=parsed.inputs,
-        )
+    parsed = parse(get_source_code(source_path))
+    if not parsed.step:
+        raise ValueError("Source is missing a call to valohai.prepare()")
+    relative_source_path = get_source_relative_path(source_path, config_path)
+    return generate_config(
+        relative_source_path=relative_source_path,
+        step=parsed.step,
+        image=DEFAULT_DOCKER_IMAGE if parsed.image is None else parsed.image,
+        parameters=parsed.parameters,
+        inputs=parsed.inputs,
+    )
 
 
 def get_parameter_type_name(name: str, value: Any) -> str:
@@ -121,3 +118,27 @@ def get_parameter_type_name(name: str, value: Any) -> str:
         "Unrecognized parameter type for %s=%s. Supported Python types are float, int, string and bool."
         % (name, value)
     )
+
+
+def get_command(relative_source_path: str) -> List[str]:
+    if is_notebook_path(relative_source_path):
+        return get_notebook_command(relative_source_path)
+
+    return [
+        "pip install -r requirements.txt",
+        "python %s {parameters}" % relative_source_path,
+    ]
+
+
+def get_source_code(source_path: str) -> str:
+    with open(source_path) as source_file:
+        file_contents = source_file.read()
+        if is_notebook_path(source_path):
+            notebook_content = parse_ipynb(file_contents)
+            return get_notebook_source_code(notebook_content)
+        return file_contents
+
+
+def is_notebook_path(source_path: str) -> bool:
+    filename, extension = os.path.splitext(source_path)
+    return extension == ".ipynb"


### PR DESCRIPTION
This PR adds notebook source file support for the YAML generator that the Valohai CLI is calling.

You can create YAML step from Python file today:

```
vh yaml step hello.py
```

Now with valohai-utils support for notebooks, you can do the same with notebooks:

```
vh yaml step hello.ipynb
```

This will generate the YAML step that runs a notebook using Papermill. The notebook is assumed to use valohai-utils to define parameters and inputs.

Note: This PR has some copy-pasta code from Jupyhai, related to parsing source code from notebooks. We don't want valohai-utils to be dependent on Jupyhai, but Jupyhai is already dependent on valohai-utils. Once this PR is merged in, we should DRY at the Jupyhai side if possible.