### PR TITLE
Allow full parameter and input definition via valohai-utils prepare()

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -12,16 +12,18 @@ def test_download(tmpdir, monkeypatch, requests_mock):
     requests_mock.get(
         "https://valohai-mnist.s3.amazonaws.com/t10k-images-idx3-ubyte.gz"
     )
-    requests_mock.get("https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg")
     requests_mock.get(
-        "https://upload.wikimedia.org/wikipedia/commons/0/01/Example_Wikipedia_sandbox_move_UI.png"
+        "https://valohai-mnist.s3.amazonaws.com/train-images-idx3-ubyte.gz"
+    )
+    requests_mock.get(
+        "https://valohai-mnist.s3.amazonaws.com/train-labels-idx1-ubyte.gz"
     )
 
     inputs = {
         "example": "https://valohai-mnist.s3.amazonaws.com/t10k-images-idx3-ubyte.gz",
-        "myimages": [
-            "https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg",
-            "https://upload.wikimedia.org/wikipedia/commons/0/01/Example_Wikipedia_sandbox_move_UI.png",
+        "mnist": [
+            "https://valohai-mnist.s3.amazonaws.com/train-images-idx3-ubyte.gz",
+            "https://valohai-mnist.s3.amazonaws.com/train-labels-idx1-ubyte.gz",
         ],
     }
 
@@ -34,12 +36,12 @@ def test_download(tmpdir, monkeypatch, requests_mock):
         == "https://valohai-mnist.s3.amazonaws.com/t10k-images-idx3-ubyte.gz"
     )
     assert (
-        load_input_info("myimages").files[0].uri
-        == "https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg"
+        load_input_info("mnist").files[0].uri
+        == "https://valohai-mnist.s3.amazonaws.com/train-images-idx3-ubyte.gz"
     )
     assert (
-        load_input_info("myimages").files[1].uri
-        == "https://upload.wikimedia.org/wikipedia/commons/0/01/Example_Wikipedia_sandbox_move_UI.png"
+        load_input_info("mnist").files[1].uri
+        == "https://valohai-mnist.s3.amazonaws.com/train-labels-idx1-ubyte.gz"
     )
 
     assert requests_mock.call_count == 3
@@ -47,11 +49,13 @@ def test_download(tmpdir, monkeypatch, requests_mock):
     assert os.path.isfile(
         os.path.join(inputs_dir, "example", "t10k-images-idx3-ubyte.gz")
     )
-    assert os.path.isfile(os.path.join(inputs_dir, "myimages", "Example.svg"))
     assert os.path.isfile(
-        os.path.join(inputs_dir, "myimages", "Example_Wikipedia_sandbox_move_UI.png")
+        os.path.join(inputs_dir, "mnist", "train-images-idx3-ubyte.gz")
+    )
+    assert os.path.isfile(
+        os.path.join(inputs_dir, "mnist", "train-labels-idx1-ubyte.gz")
     )
 
     # Second time around, the file should be cached and not trigger any more downloads
-    load_input_info("myimages")
+    load_input_info("mnist")
     assert requests_mock.call_count == 3

--- a/tests/test_parsing/test1.inputs.json
+++ b/tests/test_parsing/test1.inputs.json
@@ -1,4 +1,4 @@
 {
-  "input1": ["asdf"],
+  "input1": "asdf",
   "input2": ["yolol", "yalala"]
 }

--- a/tests/test_parsing/test3.inputs.json
+++ b/tests/test_parsing/test3.inputs.json
@@ -1,4 +1,4 @@
 {
-  "input1": ["asdf"],
+  "input1": "asdf",
   "input2": ["yolol", "yalala"]
 }

--- a/tests/test_yaml/test1.expected.valohai.yaml
+++ b/tests/test_yaml/test1.expected.valohai.yaml
@@ -26,8 +26,7 @@
       type: float
     inputs:
     - name: input1
-      default:
-      - asdf
+      default: asdf
       optional: false
     - name: input2
       default:

--- a/tests/test_yaml/test2.expected.valohai.yaml
+++ b/tests/test_yaml/test2.expected.valohai.yaml
@@ -24,8 +24,7 @@
       type: float
     inputs:
     - name: input1
-      default:
-      - asdf
+      default: asdf
       optional: false
     - name: input2
       default:

--- a/tests/test_yaml/test3.expected.valohai.yaml
+++ b/tests/test_yaml/test3.expected.valohai.yaml
@@ -26,8 +26,7 @@
       type: float
     inputs:
     - name: input1
-      default:
-      - asdf
+      default: asdf
       optional: false
     - name: input2
       default:

--- a/tests/test_yaml/test4.expected.valohai.yaml
+++ b/tests/test_yaml/test4.expected.valohai.yaml
@@ -24,8 +24,7 @@
       type: float
     inputs:
     - name: input1
-      default:
-      - asdf/*
+      default: asdf/*
       keep-directories: suffix
       optional: false
     - name: input2

--- a/tests/test_yaml/test7.expected.valohai.yaml
+++ b/tests/test_yaml/test7.expected.valohai.yaml
@@ -27,8 +27,7 @@
       type: string
     inputs:
     - name: my-image
-      default:
-      - https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg
+      default: https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg
       optional: false
     - name: my-optional-input
       optional: true

--- a/tests/test_yaml/test8.expected.valohai.yaml
+++ b/tests/test_yaml/test8.expected.valohai.yaml
@@ -1,0 +1,42 @@
+- step:
+    name: train
+    image: tensorflow/tensorflow:2.4.0-gpu
+    command:
+    - apt-get update
+    - apt-get install -y wget libsm6 libxext6 libxrender-dev
+    - pip install -r /valohai/repository/requirements-gpu.txt
+    - python convert.py --weights /valohai/inputs/weights/yolov3.weights --output
+      ./checkpoints/yolov3.tf
+    - python train.py {parameters} --classes /valohai/inputs/classes/classes.txt --weights
+      ./checkpoints/yolov3.tf --dataset /valohai/inputs/dataset/train.tfrecord --val_dataset
+      /valohai/inputs/dataset/train.tfrecord
+    parameters:
+    - name: batch_size
+      default: 32
+      description: Size of the training batch
+      multiple-separator: '!'
+      optional: true
+      pass-as: --batch:{v}
+      type: integer
+    - name: learning_rate
+      default: 0.001
+      multiple-separator: ','
+      optional: false
+      type: float
+    - name: dropout
+      default: 0.2
+      multiple-separator: ','
+      optional: false
+      type: float
+    inputs:
+    - name: classes
+      default: s3://special-bucket/foo/bar/**.txt
+      filename: asdf.txt
+      keep-directories: full
+      optional: true
+    - name: images
+      default: s3://special-bucket/images/**.jpg
+      optional: false
+    - name: weights
+      default: s3://special-bucket/weights/yolo.pb
+      optional: false

--- a/tests/test_yaml/test8.original.valohai.yaml
+++ b/tests/test_yaml/test8.original.valohai.yaml
@@ -1,0 +1,12 @@
+- step:
+    name: train
+    image: tensorflow/tensorflow:2.4.0-gpu
+    command:
+    - apt-get update
+    - apt-get install -y wget libsm6 libxext6 libxrender-dev
+    - pip install -r /valohai/repository/requirements-gpu.txt
+    - python convert.py --weights /valohai/inputs/weights/yolov3.weights --output
+      ./checkpoints/yolov3.tf
+    - python train.py {parameters} --classes /valohai/inputs/classes/classes.txt --weights
+      ./checkpoints/yolov3.tf --dataset /valohai/inputs/dataset/train.tfrecord --val_dataset
+      /valohai/inputs/dataset/train.tfrecord

--- a/tests/test_yaml/test8.py
+++ b/tests/test_yaml/test8.py
@@ -1,0 +1,31 @@
+import valohai
+
+params = {
+    "batch_size": {
+        "default": 32,
+        "type": "integer",
+        "description": "Size of the training batch",
+        "pass-as": "--batch:{v}",
+        "optional": True,
+        "multiple-separator": "!",
+    },
+    "learning_rate": {
+        "default": 0.001,
+    },
+    "dropout": 0.2,
+}
+
+inputs = {
+    "classes": {
+        "default": "s3://special-bucket/foo/bar/**.txt",
+        "optional": True,
+        "filename": "asdf.txt",
+        "keep-directories": "full",
+    },
+    "images": {
+        "default": "s3://special-bucket/images/**.jpg",
+    },
+    "weights": "s3://special-bucket/weights/yolo.pb",
+}
+
+valohai.prepare(step="train", default_parameters=params, default_inputs=inputs)

--- a/valohai/internals/parsing.py
+++ b/valohai/internals/parsing.py
@@ -1,6 +1,6 @@
 import ast
 from collections import namedtuple
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 
 def is_module_function_call(node: ast.Call, module: str, function: str) -> bool:
@@ -77,15 +77,9 @@ class PrepareParser(ast.NodeVisitor):
 
     def process_default_inputs_arg(self, key: ast.keyword) -> None:
         if isinstance(key.value, ast.Name) and key.value.id in self.assignments:
-            self.inputs = {
-                key: value if isinstance(value, List) else [value]
-                for key, value in self.assignments[key.value.id].items()
-            }
+            self.inputs = self.assignments[key.value.id]
         elif isinstance(key.value, ast.Dict):
-            self.inputs = {
-                key: value if isinstance(value, List) else [value]
-                for key, value in ast.literal_eval(key.value).items()
-            }
+            self.inputs = ast.literal_eval(key.value)
         else:
             raise NotImplementedError()
 


### PR DESCRIPTION
Today you can feed your default parameters to `prepare()` like this
```
params = {
    "learning-rate": 0.001,
    "dropout": 0.2,
}
```

After this PR, the experts have this option, too:
```
params = {
    "batch_size": {
        "default": 32,
        "type": "integer",
        "description": "Size of the training batch",
        "pass-as": "--batch:{v}",
        "optional": True,
        "multiple-separator": "!"
    }
}
```

Same works for inputs, too!

**Minor additional tweaks**: 

* If you have an input with single default, the parser no longer forces that into an array. This makes the resulting YAML cleaner.
* Changed wikimedia.org URLs to our own S3 URLs for the tests with real downloading

Fixes #56 