### PR TITLE
Recursively compress output with ** wildcards (fixes #58)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,16 +27,20 @@ def outputs_path(tmpdir, monkeypatch):
 
 @pytest.fixture
 def output_files(outputs_path):
-    os.makedirs(os.path.join(outputs_path, "folder"))
-    os.makedirs(os.path.join(outputs_path, "folder2"))
+    return create_files(outputs_path)
+
+
+def create_files(path):
+    os.makedirs(os.path.join(path, "folder"))
+    os.makedirs(os.path.join(path, "folder2"))
 
     outputs = [
-        os.path.join(outputs_path, "test1.bin"),
-        os.path.join(outputs_path, "test2.bin"),
-        os.path.join(outputs_path, "folder", "picture.jpg"),
-        os.path.join(outputs_path, "folder", "picturetoo.jpg"),
-        os.path.join(outputs_path, "folder", "imapng.png"),
-        os.path.join(outputs_path, "folder2", "asdf.dat"),
+        os.path.join(path, "test1.bin"),
+        os.path.join(path, "test2.bin"),
+        os.path.join(path, "folder", "picture.jpg"),
+        os.path.join(path, "folder", "picturetoo.jpg"),
+        os.path.join(path, "folder", "imapng.png"),
+        os.path.join(path, "folder2", "asdf.dat"),
     ]
 
     for output in outputs:

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -5,11 +5,12 @@ import zipfile
 import pytest
 
 import valohai
+from tests.conftest import create_files
 
 
 @pytest.mark.parametrize("format", ("zip", "tar", "tar.gz"))
 @pytest.mark.parametrize("remove_originals", (False, True))
-def test_compress(outputs_path, output_files, format, remove_originals):
+def test_compress(output_files, format, remove_originals):
     filename = f"hello.{format}"
     package_path = valohai.outputs("morjes").compress(
         output_files, filename, remove_originals=remove_originals
@@ -25,3 +26,34 @@ def test_compress(outputs_path, output_files, format, remove_originals):
     elif "tar" in format:
         with tarfile.open(package_path, "r:*") as tf:
             assert len(list(tf))
+
+
+@pytest.mark.parametrize("format", ("zip", "tar", "tar.gz"))
+@pytest.mark.parametrize("remove_originals", (False, True))
+@pytest.mark.parametrize("filter, expected_files", [("**", 6), ("**/*.jpg", 2)])
+def test_compress_wildcards(tmpdir, format, remove_originals, filter, expected_files):
+    source_dir = tmpdir.strpath
+    created_files = create_files(source_dir)
+
+    filename = f"hello.{format}"
+    package_path = valohai.outputs("foo").compress(
+        source=os.path.join(source_dir, filter),
+        filename=filename,
+        remove_originals=remove_originals,
+    )
+
+    for path in created_files:
+        # picture.jpg should be always compressed with our filter(s)
+        if "picture.jpg" in path:
+            assert os.path.isfile(path) != remove_originals
+
+    if format == "zip":
+        with zipfile.ZipFile(package_path) as zf:
+            assert len(zf.namelist()) == expected_files
+            # picture.jpg should be always compressed with our filter(s)
+            assert "folder/picture.jpg" in zf.namelist()
+    elif "tar" in format:
+        with tarfile.open(package_path, "r:*") as tf:
+            assert len(list(tf)) == expected_files
+            # picture.jpg should be always compressed with our filter(s)
+            assert "folder/picture.jpg" in [tarinfo.name for tarinfo in list(tf)]

--- a/valohai/internals/files.py
+++ b/valohai/internals/files.py
@@ -2,7 +2,7 @@ import glob
 import os
 import pathlib
 from stat import S_IREAD, S_IRGRP, S_IROTH
-from typing import Set, Union
+from typing import Set, Tuple, Union
 
 
 def set_file_read_only(path: str) -> None:
@@ -16,16 +16,36 @@ def get_glob_pattern(source: str) -> str:
     return source
 
 
-def expand_globs(sources: Union[str, list], preprocessor=lambda s: s) -> Set[str]:
+def expand_globs(
+    sources: Union[str, list], preprocessor=lambda s: s
+) -> Set[Tuple[str, str]]:
+    """Returns a set of paths as a result of expanding all the source wildcards
+
+    First item of the resulting tuple item is the expanded path
+    Second item of the resulting tuple is the logical root path
+
+    Example
+    source: /tmp/foo/**/*.png
+    output: set(("/tmp/foo/bar/hello.png", "/tmp/foo"), ("/tmp/foo/bar/sub/jello.png", "/tmp/foo"))
+
+    source: /tmp/yeah/*.png
+    output: set(("/tmp/yeah/hello.png", "/tmp/yeah"), ("/tmp/yeah/jello.png", "/tmp/yeah"))
+
+    :param sources: Path or list of paths. May contain * or ** wildcards.
+    :param preprocessor: Preprocessor to be used for each of the paths
+    :return:
+    """
+
     if isinstance(sources, str):
         sources = [sources]
     files_to_compress = set()
     for source_path in sources:
         source_path = preprocessor(source_path)
         glob_pattern = get_glob_pattern(source_path)
-        for file_path in glob.glob(glob_pattern):
+        root_path = os.path.dirname(glob_pattern).split("*", 1)[0]  # Handles ** also
+        for file_path in glob.glob(glob_pattern, recursive=True):
             if os.path.isfile(file_path):
-                files_to_compress.add(file_path)
+                files_to_compress.add((file_path, root_path))
     if not files_to_compress:
         raise ValueError(f"No files to compress at {sources}")
     return files_to_compress

--- a/valohai/outputs.py
+++ b/valohai/outputs.py
@@ -20,20 +20,21 @@ class Output:
     def path(self, filename: str, makedirs: bool = True) -> str:
         """Absolute path of an output file
 
-        Compress files into a temporary file, which is then copied to the target path.
-        Optionally removes original files and live uploads the package.
+        The main use-case is to provide absolute path for an relative path.
+        You can also feed it absolute path and it will always return you one back.
 
-        Returns the absolute path to the created package.
-
-        :param filename: Name of the file. Can also include sub path (example: myfolder/hello.txt)
+        :param filename: Name of the file. Can be relative or absolute (example: myfolder/hello.txt, /tmp/foo/hello.txt)
         :param makedirs: Auto-create folders if they do not exist.
 
         """
         path = get_outputs_path()
 
         # To guard against absolute paths in the output name.
+        # For example valohai.outputs('/home/johndoe/herpderp/outputs/images') instead of valohai.outputs('images')
+
         # If the absolute path is in the outputs dir, the path will be made relative.
-        # If it is some other absolute path, an exception is raised.
+        # If the output name is some other absolute path, an exception is raised.
+
         if os.path.isabs(self.name):
             if self.name.startswith(path):
                 self.name = os.path.relpath(self.name, path)
@@ -45,7 +46,12 @@ class Output:
         if self.name:
             path = os.path.join(path, self.name)
 
-        path = os.path.join(path, filename)
+        # Simple os.path.join() call would get us the same result, but
+        # The behavior for joining two absolute paths is made explicit here for clarity
+        if os.path.isabs(filename):
+            path = filename
+        else:
+            path = os.path.join(path, filename)
 
         if makedirs:
             os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -78,7 +84,6 @@ class Output:
         """
         target_path = self.path(filename)
         files_to_compress = expand_globs(source, preprocessor=self.path)
-        common_prefix = os.path.commonprefix(list(files_to_compress))
 
         # We can't use `delete=True` since we need to replace the file later, and moving
         # the `os.replace()` call within the block if it has delete=True means there'll be an
@@ -90,8 +95,8 @@ class Output:
         )
         with tmp_file, open_archive(tmp_file.name) as archive:  # type: ignore
             compressed_paths = []
-            for file_path in files_to_compress:
-                arc_path = os.path.relpath(file_path, common_prefix)
+            for file_path, root_path in files_to_compress:
+                arc_path = os.path.relpath(file_path, root_path)
                 archive.put(arc_path, file_path)
                 compressed_paths.append(file_path)
 


### PR DESCRIPTION
You can now make calls like:
```
# relative paths
valohai.outputs('resized').compress("**/*.png", "images.zip", remove_originals=True)

# absolute paths
valohai.outputs('resized').compress("/tmp/foo/**/derp/*.png", "images.zip", remove_originals=True)
```
And get a meaningful folder structure inside the archive:
```
train/hello.png
test/jello.png
```

fixes #58 