### PR TITLE
Add dir_path property to inputs (fixes #51)

### DIFF
--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -6,6 +6,9 @@ import valohai
 def test_get_input_paths(use_test_config_dir):
     assert valohai.inputs("single_image").path().endswith("single_image/Example.jpg")
     assert os.path.exists(valohai.inputs("single_image").path())
+    assert os.path.exists(valohai.inputs("single_image").dir_path)
+    assert os.path.isdir(valohai.inputs("single_image").dir_path)
+
     assert (
         valohai.inputs("single_image")
         .path(default="unused_default")

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -6,8 +6,8 @@ import valohai
 def test_get_input_paths(use_test_config_dir):
     assert valohai.inputs("single_image").path().endswith("single_image/Example.jpg")
     assert os.path.exists(valohai.inputs("single_image").path())
-    assert os.path.exists(valohai.inputs("single_image").dir_path)
-    assert os.path.isdir(valohai.inputs("single_image").dir_path)
+    assert os.path.exists(valohai.inputs("single_image").dir_path())
+    assert os.path.isdir(valohai.inputs("single_image").dir_path())
 
     assert (
         valohai.inputs("single_image")

--- a/valohai/inputs.py
+++ b/valohai/inputs.py
@@ -4,6 +4,7 @@ from valohai.internals.download_type import DownloadType
 
 from .internals import vfs
 from .internals.input_info import load_input_info
+from .paths import get_inputs_path
 
 
 class Input:
@@ -151,6 +152,12 @@ class Input:
                     process_archives=process_archives,
                 )
         return v
+
+    @property
+    def dir_path(
+        self,
+    ) -> str:
+        return get_inputs_path(self.name)
 
 
 inputs = Input

--- a/valohai/inputs.py
+++ b/valohai/inputs.py
@@ -153,7 +153,6 @@ class Input:
                 )
         return v
 
-    @property
     def dir_path(
         self,
     ) -> str:


### PR DESCRIPTION
Shortcut to get input folder path:

```
valohai.inputs("my_images").dir_path
```

One aesthetical decision here was that we have `valohai.inputs("my_images").path("file.txt")` and it might be considered consistent to have `valohai.inputs("my_images").dir_path()` method instead of property. 

I chose property over method but can be argued either way.

fixes #51 