### PR TITLE
Fix path separator for generated YAML on Windows (fixes #68)

### DIFF
--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -6,7 +6,7 @@ from valohai_yaml import parse
 
 from tests.utils import read_yaml_test_data
 from valohai.internals.merge import python_to_yaml_merge_strategy
-from valohai.internals.yaml import parse_config_from_source
+from valohai.internals.yaml import generate_step, parse_config_from_source
 from valohai.yaml import config_to_yaml
 
 
@@ -41,3 +41,19 @@ def test_yaml_update_from_source(tmpdir, original_yaml, source_python, expected_
     with open(expected_yaml) as expected_yaml:
         new_yaml = config_to_yaml(new_config)
         assert new_yaml == expected_yaml.read()
+
+
+def test_posix_path_separator(monkeypatch):
+    # Let's be sneaky and force the path separator to simulate Windows
+    monkeypatch.setattr(os, "sep", "\\")
+
+    step = generate_step(
+        relative_source_path="subfolder\\foo\\bar\\train.py",
+        step="train",
+        image="python:3.8",
+        parameters={},
+        inputs={},
+    )
+
+    # We expect the path separator be POSIX now
+    assert any("subfolder/foo/bar/train.py" in command for command in step.command)

--- a/valohai/internals/yaml.py
+++ b/valohai/internals/yaml.py
@@ -146,6 +146,10 @@ def get_parameter_type_name(name: str, value: Any) -> str:
 
 
 def get_command(relative_source_path: str) -> List[str]:
+    # We need to generate a POSIX-compliant command, even if we are running this method in Windows
+    # The path separator must be forced to POSIX
+    relative_source_path = relative_source_path.replace(os.sep, "/")
+
     if is_notebook_path(relative_source_path):
         return get_notebook_command(relative_source_path)
 


### PR DESCRIPTION
If you generate YAML on a Windows machine, you still want the path separator to be POSIX.

fixes #68 