### PR TITLE
Fix local inputs with multiple files + add tests

### DIFF
--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -11,6 +11,12 @@ def test_prepare(tmpdir, monkeypatch):
     local_file = tmpdir.mkdir("sub").join("hello.txt")
     local_file.write("tiku ja taku ja joku")
 
+    data_dir = tmpdir.mkdir("data")
+    local_data = data_dir.join("data1.dat")
+    local_data.write("I'm a big data")
+    local_data2 = data_dir.join("data2.dat")
+    local_data2.write("I'm a huge data")
+
     parameters = {
         "iambool": True,
         "mestringy": "asdf",
@@ -28,6 +34,8 @@ def test_prepare(tmpdir, monkeypatch):
             "https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg",
             "https://upload.wikimedia.org/wikipedia/commons/0/01/Example_Wikipedia_sandbox_move_UI.png",
         ],
+        "localdata_as_list": [str(local_data), str(local_data2)],
+        "localdata_with_wildcard": os.path.join(str(data_dir), "*.dat"),
     }
 
     with monkeypatch.context() as m:
@@ -72,3 +80,12 @@ def test_prepare(tmpdir, monkeypatch):
     )
     assert not get_input_info("overrideme").files[0].uri
     assert os.path.isfile(get_input_info("overrideme").files[0].path)
+
+    assert sum(1 for _ in valohai.inputs("localdata_as_list").paths()) == 2
+    assert sum(1 for _ in valohai.inputs("localdata_with_wildcard").paths()) == 2
+
+    for p in valohai.inputs("localdata_as_list").paths():
+        assert os.path.isfile(p)
+
+    for p in valohai.inputs("localdata_with_wildcard").paths():
+        assert os.path.isfile(p)

--- a/valohai/internals/input_info.py
+++ b/valohai/internals/input_info.py
@@ -76,7 +76,7 @@ class InputInfo:
                         FileInfo(
                             name=os.path.basename(path),
                             uri=None,
-                            path=value,
+                            path=path,
                             size=None,
                             checksums=None,
                         )


### PR DESCRIPTION
Wildcards were broken for local paths. List of local paths used to be broken, too.

This code:
```
valohai.prepare(step="train", default_inputs={"myinput": "*.png"})
```
Would try to download the local file path and throw an error. This PR fixes it.

Also lists as default for local inputs:
```
valohai.prepare(step="train", default_inputs={"myinput": ["1.png", "2.png"]})
```
Were fixed in the big refactor earlier, but this PR adds a test for it.

Fixes #76 
Fixes #65 