### PR TITLE
Make NotImplementedErrors more verbose

### DIFF
--- a/valohai/internals/compression.py
+++ b/valohai/internals/compression.py
@@ -59,7 +59,7 @@ class BaseArchive:
     """
 
     def put(self, archive_name: str, source: FilenameOrStream) -> None:
-        raise NotImplementedError("...")
+        raise NotImplementedError(f"{self.__class__.__name__}.put() not implemented")
 
 
 class ZipArchive(BaseArchive, zipfile.ZipFile):

--- a/valohai/internals/parsing.py
+++ b/valohai/internals/parsing.py
@@ -78,21 +78,18 @@ class PrepareParser(ast.NodeVisitor):
                 elif key.arg == "image":
                     self.image = ast.literal_eval(key.value)
 
-    def process_default_inputs_arg(self, key: ast.keyword) -> None:
+    def _process_kwarg(self, key: ast.keyword, *, error_hint: str = "") -> Any:
         if isinstance(key.value, ast.Name) and key.value.id in self.assignments:
-            self.inputs = self.assignments[key.value.id]
-        elif isinstance(key.value, ast.Dict):
-            self.inputs = ast.literal_eval(key.value)
-        else:
-            raise NotImplementedError()
+            return self.assignments[key.value.id]
+        if isinstance(key.value, ast.Dict):
+            return ast.literal_eval(key.value)
+        raise NotImplementedError(f"Unable to parse {error_hint}: {key.value!r}")
+
+    def process_default_inputs_arg(self, key: ast.keyword) -> None:
+        self.inputs = self._process_kwarg(key, error_hint="inputs=")
 
     def process_default_parameters_arg(self, key: ast.keyword) -> None:
-        if isinstance(key.value, ast.Name) and key.value.id in self.assignments:
-            self.parameters = self.assignments[key.value.id]
-        elif isinstance(key.value, ast.Dict):
-            self.parameters = ast.literal_eval(key.value)
-        else:
-            raise NotImplementedError()
+        self.parameters = self._process_kwarg(key, error_hint="parameters=")
 
 
 def parse(source: str) -> ParseResult:

--- a/valohai/internals/vfs.py
+++ b/valohai/internals/vfs.py
@@ -16,7 +16,7 @@ class File:
     parent_file: Optional["File"] = None
 
     def open(self) -> IO[bytes]:
-        raise NotImplementedError("...")
+        raise NotImplementedError(f"{self.__class__.__name__}.open() not implemented")
 
     def read(self) -> bytes:
         with self.open() as f:
@@ -27,7 +27,7 @@ class File:
 
     @property
     def name(self) -> str:
-        raise NotImplementedError("...")
+        raise NotImplementedError(f"{self.__class__.__name__}.name not implemented")
 
     @property
     def extension(self) -> str:


### PR DESCRIPTION
Better to get a real error, not just `raise NotImplementedError(): NotImplementedError`.