### PR TITLE
Add `valohai.set_status_detail`

### DIFF
--- a/valohai/__init__.py
+++ b/valohai/__init__.py
@@ -2,6 +2,7 @@ __version__ = "0.2.0"
 
 import papi
 
+from valohai.controller_api import set_status_detail
 from valohai.inputs import inputs
 from valohai.internals.global_state import distributed
 from valohai.metadata import logger
@@ -19,4 +20,5 @@ __all__ = [
     "parameters",
     "prepare",
     "Pipeline",
+    "set_status_detail",
 ]

--- a/valohai/controller_api.py
+++ b/valohai/controller_api.py
@@ -1,0 +1,18 @@
+import warnings
+
+
+def set_status_detail(status_detail: str) -> None:
+    """
+    Attempt to set the status detail of the current execution.
+    """
+    try:
+        from valohai.internals.api_calls import send_api_request
+
+        send_api_request(
+            endpoint="set_status_detail",
+            json={"status_detail": status_detail},
+        )
+    except FileNotFoundError:  # No API configuration file, no need to warn
+        pass
+    except Exception as exc:
+        warnings.warn(f"Status detail send failed: {exc}")

--- a/valohai/internals/api_calls.py
+++ b/valohai/internals/api_calls.py
@@ -1,0 +1,47 @@
+import json
+from typing import TYPE_CHECKING, Any, Dict
+
+from valohai import paths
+
+if TYPE_CHECKING:
+    import requests
+
+
+def get_api_requests_kwargs(endpoint: str) -> Dict[str, Any]:
+    """
+    Get the "presigned call" dict for a given endpoint from the
+    API JSON configuration file.  Will happily throw all sorts of
+    exceptions e.g. if the API JSON file is missing or malformed.
+    """
+    with open(paths.get_api_config_path()) as json_file:
+        api_config = json.load(json_file)
+    value = api_config.get(endpoint)
+    if not (isinstance(value, dict) and value.get("url")):
+        raise ValueError(f"Invalid API config for {endpoint}")
+    return value
+
+
+def send_api_request(
+    endpoint: str,
+    **requests_kwargs: Any,
+) -> "requests.Response":
+    """
+    Send an API request to the named endpoint.
+
+    Will happily throw all sorts of exceptions; it is the caller's
+    responsibility to handle them in a suitable way.
+
+    :param endpoint: The endpoint to send the request to.  Will be
+                     looked up in the API JSON configuration file.
+    :param requests_kwargs: Any keyword arguments to pass to the
+                            requests.request() function.  You can expect
+                            `url` and `method` and likely `headers` to
+                            have been set for you.
+    """
+    import requests
+
+    requests_config = get_api_requests_kwargs(endpoint)
+    requests_config.update(requests_kwargs)
+    resp = requests.request(**requests_config)
+    resp.raise_for_status()
+    return resp

--- a/valohai/paths.py
+++ b/valohai/paths.py
@@ -64,3 +64,7 @@ def get_parameters_config_path() -> str:
 
 def get_distributed_config_path() -> str:
     return os.path.join(get_config_path(), "distributed.json")
+
+
+def get_api_config_path() -> str:
+    return os.path.join(get_config_path(), "api.json")


### PR DESCRIPTION
This PR adds a helper function `valohai.set_status_detail`.

It requires `requests` to be installed; it's not a dependency at all for `valohai-utils` (and likely will never be).