### PR TITLE
Output path

### DIFF
--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -12,6 +12,8 @@ def test_get_output_path(outputs_path, name, fragment):
     path = valohai.outputs(name).path(fragment)
     assert path == os.path.join(outputs_path, name, fragment)
     assert os.path.isdir(os.path.dirname(path))
+    assert os.path.exists(valohai.outputs().dir_path)
+    assert os.path.isdir(valohai.outputs().dir_path)
 
 
 def test_live_upload(outputs_path):

--- a/valohai/outputs.py
+++ b/valohai/outputs.py
@@ -2,6 +2,7 @@ import glob
 import os
 import tempfile
 from typing import List, Union
+from .paths import get_outputs_path
 
 from valohai.internals.compression import open_archive
 from valohai.internals.files import (
@@ -110,5 +111,10 @@ class Output:
 
         return target_path
 
+    @property
+    def dir_path(
+        self,
+    ) -> str:
+        return get_outputs_path(self.name)
 
 outputs = Output

--- a/valohai/outputs.py
+++ b/valohai/outputs.py
@@ -2,7 +2,6 @@ import glob
 import os
 import tempfile
 from typing import List, Union
-from .paths import get_outputs_path
 
 from valohai.internals.compression import open_archive
 from valohai.internals.files import (
@@ -115,6 +114,7 @@ class Output:
     def dir_path(
         self,
     ) -> str:
-        return get_outputs_path(self.name)
+        return get_outputs_path()
+
 
 outputs = Output


### PR DESCRIPTION
Pretty much this https://github.com/valohai/valohai-utils/pull/67 except for outputs

Shortcut to get output folder path:

```
valohai.outputs().dir_path
```