### PR TITLE
Replace third-party URLs in tests with ours

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ default_parameters = {
 }
 default_inputs = {
     "images": [
-        "https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg",
-        "https://homepages.cae.wisc.edu/~ece533/images/airplane.png",
+        "https://dist.valohai.com/valohai-utils-tests/Example.jpg",
+        "https://dist.valohai.com/valohai-utils-tests/planeshark.jpg",
     ],
 }
 
@@ -265,8 +265,8 @@ Will produce this `valohai.yaml` config:
     inputs:
     - name: images
       default:
-      - https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg
-      - https://homepages.cae.wisc.edu/~ece533/images/airplane.png
+      - https://dist.valohai.com/valohai-utils-tests/Example.jpg
+      - https://dist.valohai.com/valohai-utils-tests/planeshark.jpg
       optional: false
 ```
 

--- a/tests/test_parsing_priorities.py
+++ b/tests/test_parsing_priorities.py
@@ -46,7 +46,7 @@ def test_parsing_priorities(tmpdir, monkeypatch):
                     "files": [
                         {
                             "name": "example.svg",
-                            "uri": "https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg",
+                            "uri": "https://dist.valohai.com/valohai-utils-tests/Example.svg",
                             "path": None,
                             "size": 0,
                             "checksums": [],
@@ -62,7 +62,7 @@ def test_parsing_priorities(tmpdir, monkeypatch):
     valohai.prepare(step="test", default_parameters=parameters, default_inputs=inputs)
     assert (
         get_input_info("example").files[0].uri
-        == "https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg"
+        == "https://dist.valohai.com/valohai-utils-tests/Example.svg"
     )
     assert valohai.parameters("floaty").value == 0.5
 

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -28,12 +28,14 @@ def test_prepare(tmpdir, monkeypatch):
         "makeme321": 123,
         "makemenegative": 0.0001,
     }
+    url1 = "https://dist.valohai.com/valohai-utils-tests/Example.svg"
+    url2 = "https://dist.valohai.com/valohai-utils-tests/sharktavern.jpg"
     inputs = {
         "example": "https://valohai-mnist.s3.amazonaws.com/t10k-images-idx3-ubyte.gz",
         "overrideme": "https://valohai-mnist.s3.amazonaws.com/t10k-images-idx3-ubyte.gz",
         "myimages": [
-            "https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg",
-            "https://upload.wikimedia.org/wikipedia/commons/0/01/Example_Wikipedia_sandbox_move_UI.png",
+            url1,
+            url2,
         ],
         "localdata_as_list": [str(local_data), str(local_data2)],
         "localdata_with_wildcard": os.path.join(str(data_dir), "*.dat"),
@@ -73,14 +75,9 @@ def test_prepare(tmpdir, monkeypatch):
         get_input_info("example").files[0].uri
         == "https://valohai-mnist.s3.amazonaws.com/t10k-images-idx3-ubyte.gz"
     )
-    assert (
-        get_input_info("myimages").files[0].uri
-        == "https://upload.wikimedia.org/wikipedia/commons/8/84/Example.svg"
-    )
-    assert (
-        get_input_info("myimages").files[1].uri
-        == "https://upload.wikimedia.org/wikipedia/commons/0/01/Example_Wikipedia_sandbox_move_UI.png"
-    )
+    images = get_input_info("myimages").files
+    assert images[0].uri == url1
+    assert images[1].uri == url2
     assert not get_input_info("overrideme").files[0].uri
     assert os.path.isfile(get_input_info("overrideme").files[0].path)
 

--- a/tests/test_yaml/test7.expected.valohai.yaml
+++ b/tests/test_yaml/test7.expected.valohai.yaml
@@ -29,7 +29,7 @@
       type: string
     inputs:
     - name: my-image
-      default: https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg
+      default: https://dist.valohai.com/valohai-utils-tests/Example.jpg
       optional: false
     - name: my-optional-input
       optional: true

--- a/tests/test_yaml/test7.ipynb
+++ b/tests/test_yaml/test7.ipynb
@@ -17,7 +17,7 @@
     "}\n",
     "\n",
     "inputs = {\n",
-    "    \"my-image\": \"https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg\",\n",
+    "    \"my-image\": \"https://dist.valohai.com/valohai-utils-tests/Example.jpg\",\n",
     "    \"my-optional-input\": \"\",\n",
     "}\n",
     "\n",

--- a/tests/valohai_test_environment.py
+++ b/tests/valohai_test_environment.py
@@ -62,7 +62,7 @@ class ValohaiTestEnvironment:
                         "name": "Example.jpg",
                         "path": f"{self.inputs_path}/single_image/Example.jpg",
                         "size": 27661,
-                        "uri": "https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg",
+                        "uri": "https://dist.valohai.com/valohai-utils-tests/Example.jpg",
                     }
                 ]
             },


### PR DESCRIPTION
Wikimedia was complaining about our generic user-agent: https://github.com/valohai/valohai-utils/actions/runs/3351039320/jobs/5552232384