### PR TITLE
Maintain valohai-yaml related tests

### DIFF
--- a/tests/test_pipeline_yaml/test1.expected.valohai.yaml
+++ b/tests/test_pipeline_yaml/test1.expected.valohai.yaml
@@ -13,7 +13,6 @@
     - name: learning_rate
       default: 0.001
       description: Initial learning rate
-      multiple-separator: ','
       optional: false
       pass-as: --learning_rate={v}
       type: float

--- a/tests/test_pipeline_yaml/test1.expected.valohai.yaml
+++ b/tests/test_pipeline_yaml/test1.expected.valohai.yaml
@@ -5,14 +5,6 @@
     - date > /valohai/outputs/aaa.md5
     - date > /valohai/outputs/bbb.sha256
 - step:
-    name: Evaluate
-    image: ubuntu:18.04
-    command:
-    - ls -lar
-    inputs:
-    - name: models
-      optional: false
-- step:
     name: Train model
     image: ubuntu:18.04
     command:
@@ -30,6 +22,14 @@
       optional: false
     - name: bbb
       optional: false
+- step:
+    name: Evaluate
+    image: ubuntu:18.04
+    command:
+    - ls -lar
+    inputs:
+    - name: models
+      optional: false
 - pipeline:
     name: mypipeline
     edges:
@@ -45,16 +45,13 @@
     nodes:
     - name: batch_feature_extraction_1
       on-error: stop-all
-      override: {}
       step: Batch feature extraction
       type: execution
     - name: train_model_1
       on-error: stop-all
-      override: {}
       step: Train model
       type: task
     - name: evaluate_1
       on-error: stop-all
-      override: {}
       step: Evaluate
       type: execution

--- a/tests/test_yaml/test1.expected.valohai.yaml
+++ b/tests/test_yaml/test1.expected.valohai.yaml
@@ -1,4 +1,8 @@
 - step:
+    name: herpderp
+    image: busybox
+    command: python ./yomama.py {parameters}
+- step:
     name: foobar1
     image: python:3.7
     command:
@@ -37,7 +41,3 @@
       optional: false
     - name: my-optional-input
       optional: true
-- step:
-    name: herpderp
-    image: busybox
-    command: python ./yomama.py {parameters}

--- a/tests/test_yaml/test1.expected.valohai.yaml
+++ b/tests/test_yaml/test1.expected.valohai.yaml
@@ -11,23 +11,19 @@
     parameters:
     - name: param1
       default: true
-      multiple-separator: ','
       pass-false-as: --param1=false
       pass-true-as: --param1=true
       type: flag
     - name: param2
       default: asdf
-      multiple-separator: ','
       optional: false
       type: string
     - name: param3
       default: 123
-      multiple-separator: ','
       optional: false
       type: integer
     - name: param4
       default: 0.0001
-      multiple-separator: ','
       optional: false
       type: float
     inputs:

--- a/tests/test_yaml/test2.expected.valohai.yaml
+++ b/tests/test_yaml/test2.expected.valohai.yaml
@@ -5,23 +5,19 @@
     parameters:
     - name: param1
       default: true
-      multiple-separator: ','
       pass-false-as: --param1=false
       pass-true-as: --param1=true
       type: flag
     - name: param2
       default: asdf
-      multiple-separator: ','
       optional: false
       type: string
     - name: param3
       default: 123
-      multiple-separator: ','
       optional: false
       type: integer
     - name: param4
       default: 0.0001
-      multiple-separator: ','
       optional: false
       type: float
     inputs:

--- a/tests/test_yaml/test3.expected.valohai.yaml
+++ b/tests/test_yaml/test3.expected.valohai.yaml
@@ -7,23 +7,19 @@
     parameters:
     - name: param1
       default: true
-      multiple-separator: ','
       pass-false-as: --param1=false
       pass-true-as: --param1=true
       type: flag
     - name: param2
       default: asdf
-      multiple-separator: ','
       optional: false
       type: string
     - name: param3
       default: 123
-      multiple-separator: ','
       optional: false
       type: integer
     - name: param4
       default: 0.0001
-      multiple-separator: ','
       optional: false
       type: float
     inputs:

--- a/tests/test_yaml/test4.expected.valohai.yaml
+++ b/tests/test_yaml/test4.expected.valohai.yaml
@@ -5,23 +5,19 @@
     parameters:
     - name: param1
       default: true
-      multiple-separator: ','
       pass-false-as: --param1=false
       pass-true-as: --param1=true
       type: flag
     - name: param2
       default: asdf
-      multiple-separator: ','
       optional: false
       type: string
     - name: param3
       default: 123
-      multiple-separator: ','
       optional: false
       type: integer
     - name: param4
       default: 0.0001
-      multiple-separator: ','
       optional: false
       type: float
     inputs:

--- a/tests/test_yaml/test4.expected.valohai.yaml
+++ b/tests/test_yaml/test4.expected.valohai.yaml
@@ -59,11 +59,9 @@
     nodes:
     - name: generate
       on-error: stop-all
-      override: {}
       step: generate-dataset
       type: execution
     - name: train
       on-error: stop-all
-      override: {}
       step: train-model
       type: execution

--- a/tests/test_yaml/test5.expected.valohai.yaml
+++ b/tests/test_yaml/test5.expected.valohai.yaml
@@ -5,12 +5,10 @@
     parameters:
     - name: seq_length
       default: 14
-      multiple-separator: ','
       optional: false
       type: integer
     - name: num_epochs
       default: 200
-      multiple-separator: ','
       optional: false
       type: integer
     environment: big-cpu-box

--- a/tests/test_yaml/test6.expected.valohai.yaml
+++ b/tests/test_yaml/test6.expected.valohai.yaml
@@ -8,12 +8,10 @@
     parameters:
     - name: iterations
       default: 500
-      multiple-separator: ','
       optional: false
       type: integer
     - name: learning-rate
       default: 0.001
-      multiple-separator: ','
       optional: false
       type: float
     inputs:

--- a/tests/test_yaml/test7.expected.valohai.yaml
+++ b/tests/test_yaml/test7.expected.valohai.yaml
@@ -8,23 +8,19 @@
     parameters:
     - name: epochs
       default: 500
-      multiple-separator: ','
       optional: false
       type: integer
     - name: learning-rate
       default: 0.001
-      multiple-separator: ','
       optional: false
       type: float
     - name: flaggy
       default: true
-      multiple-separator: ','
       pass-false-as: --flaggy=false
       pass-true-as: --flaggy=true
       type: flag
     - name: stringy
       default: holla
-      multiple-separator: ','
       optional: false
       type: string
     inputs:

--- a/tests/test_yaml/test8.expected.valohai.yaml
+++ b/tests/test_yaml/test8.expected.valohai.yaml
@@ -14,18 +14,15 @@
     - name: batch_size
       default: 32
       description: Size of the training batch
-      multiple-separator: '!'
       optional: true
       pass-as: --batch:{v}
       type: integer
     - name: learning_rate
       default: 0.001
-      multiple-separator: ','
       optional: false
       type: float
     - name: dropout
       default: 0.2
-      multiple-separator: ','
       optional: false
       type: float
     inputs:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,8 @@ import glob
 import json
 import os
 
+from difflib import unified_diff as diff
+
 from valohai_yaml.objs import Config
 
 from valohai.yaml import config_to_yaml
@@ -64,4 +66,4 @@ def read_yaml_test_data(root_path):
 
 def compare_yaml(config: Config, fixture_yaml: str) -> None:
     generated_yaml = config_to_yaml(config)
-    assert generated_yaml == fixture_yaml
+    assert generated_yaml == fixture_yaml, diff(generated_yaml, fixture_yaml)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,4 +63,5 @@ def read_yaml_test_data(root_path):
 
 
 def compare_yaml(config: Config, fixture_yaml: str) -> None:
-    assert config_to_yaml(config) == fixture_yaml
+    generated_yaml = config_to_yaml(config)
+    assert generated_yaml == fixture_yaml


### PR DESCRIPTION
Valohai-yaml has recently updated its serialisation logic, which breaks valohai-utils test suite due to exact YAML string representation comparisons done here.

Test suite will pass once valohai-yaml PR https://github.com/valohai/valohai-yaml/pull/106 is merged and new release is prepared. 

This should be an exhaustive list of valohai-yaml updates maintained in this PR:

- multiple-separator is not rendered where not applicable https://github.com/valohai/valohai-yaml/pull/106
- Override is rendered differently https://github.com/valohai/valohai-yaml/pull/103
- steps sorting has changed https://github.com/valohai/valohai-yaml/pull/93

In addition, test suite is improved to output diffs of failed YAML tests to make future maintenance more straightforward.

We could consider some kind of reverse-dependency test workflow on valohai-yaml to let us know when tests begin failing downstream.