### PR TITLE
Specify build target for wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,12 @@ include = [
     "/valohai",
 ]
 
+[tool.hatch.build.targets.wheel]
+packages = [
+    "/valohai",
+]
+
+
 [tool.black]
 target-version = ["py37"]
 


### PR DESCRIPTION
Newer version of `hatch` will require the target to be specify when the our python package name is not the same as its pip package name.