### PR TITLE
Ignore default value for inputs if it's local file path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ venv.bak/
 # JetBrains IDEs
 .idea/
 
+# Vscode
+.vscode
+
 # Rope project settings
 .ropeproject
 

--- a/tests/test_yaml/test1.expected.valohai.yaml
+++ b/tests/test_yaml/test1.expected.valohai.yaml
@@ -28,12 +28,12 @@
       type: float
     inputs:
     - name: input1
-      default: asdf
+      default:
+      - datum://asdf
       optional: false
     - name: input2
       default:
-      - yolol
-      - yalala
+      - datum://yolol
       optional: false
     - name: my-optional-input
       optional: true

--- a/tests/test_yaml/test1.py
+++ b/tests/test_yaml/test1.py
@@ -7,7 +7,14 @@ params = {
     "param4": 0.0001,
 }
 
-inputs = {"input1": "asdf", "input2": ["yolol", "yalala"], "my-optional-input": ""}
+inputs = {
+    "input1": "datum://asdf",
+    "input2": [
+        "datum://yolol",
+        "yalala",  # this local path should be ignored
+    ],
+    "my-optional-input": "",
+}
 
 
 def prepare(a, b):

--- a/tests/test_yaml/test2.expected.valohai.yaml
+++ b/tests/test_yaml/test2.expected.valohai.yaml
@@ -22,10 +22,11 @@
       type: float
     inputs:
     - name: input1
-      default: asdf
+      default:
+      - datum://asdf
       optional: false
     - name: input2
       default:
-      - yolol
-      - yalala
+      - datum://yolol
+      - datum://yalala
       optional: false

--- a/tests/test_yaml/test2.py
+++ b/tests/test_yaml/test2.py
@@ -7,7 +7,7 @@ params = {
     "param4": 0.0001,
 }
 
-inputs = {"input1": "asdf", "input2": ["yolol", "yalala"]}
+inputs = {"input1": "datum://asdf", "input2": ["datum://yolol", "datum://yalala"]}
 
 
 def prepare(a, b):

--- a/tests/test_yaml/test3.expected.valohai.yaml
+++ b/tests/test_yaml/test3.expected.valohai.yaml
@@ -24,10 +24,9 @@
       type: float
     inputs:
     - name: input1
-      default: asdf
-      optional: false
+      optional: true
     - name: input2
       default:
-      - yolol
-      - yalala
+      - datum://yolol
+      - datum://yalala
       optional: false

--- a/tests/test_yaml/test3.py
+++ b/tests/test_yaml/test3.py
@@ -7,7 +7,10 @@ params = {
     "param4": 0.0001,
 }
 
-inputs = {"input1": "asdf", "input2": ["yolol", "yalala"]}
+inputs = {
+    "input1": "asdf",  # local path
+    "input2": ["datum://yolol", "datum://yalala"],
+}
 
 
 def prepare(a, b):

--- a/tests/test_yaml/test4.expected.valohai.yaml
+++ b/tests/test_yaml/test4.expected.valohai.yaml
@@ -22,14 +22,9 @@
       type: float
     inputs:
     - name: input1
-      default: asdf/*
-      keep-directories: suffix
-      optional: false
+      optional: true
     - name: input2
-      default:
-      - yolol
-      - yalala
-      optional: false
+      optional: true
 - step:
     name: herpderp
     image: busybox

--- a/tests/test_yaml/test4.py
+++ b/tests/test_yaml/test4.py
@@ -7,7 +7,10 @@ params = {
     "param4": 0.0001,
 }
 
-inputs = {"input1": "asdf/*", "input2": ["yolol", "yalala"]}
+inputs = {
+    "input1": "asdf/*",
+    "input2": ["yolol", "yalala"],
+}
 
 
 def prepare(a, b):

--- a/tests/test_yaml/test7.expected.valohai.yaml
+++ b/tests/test_yaml/test7.expected.valohai.yaml
@@ -25,7 +25,8 @@
       type: string
     inputs:
     - name: my-image
-      default: https://dist.valohai.com/valohai-utils-tests/Example.jpg
+      default:
+      - https://dist.valohai.com/valohai-utils-tests/Example.jpg
       optional: false
     - name: my-optional-input
       optional: true

--- a/tests/test_yaml/test8.expected.valohai.yaml
+++ b/tests/test_yaml/test8.expected.valohai.yaml
@@ -35,5 +35,6 @@
       default: s3://special-bucket/images/**.jpg
       optional: false
     - name: weights
-      default: s3://special-bucket/weights/yolo.pb
+      default:
+      - s3://special-bucket/weights/yolo.pb
       optional: false

--- a/valohai/internals/utils.py
+++ b/valohai/internals/utils.py
@@ -18,3 +18,9 @@ def get_sha256_hash(filepath: str) -> str:
 
     with open(filepath, "rb") as f:
         return get_fp_sha256(f)  # type: ignore
+
+
+def is_local_file_path(path_str: str) -> bool:
+    if "://" in path_str:
+        return False
+    return True


### PR DESCRIPTION
Resolve #49 

When generating/updating config to `valohai.yaml`, we will ignore the value of inputs if it's pointing to a local file path