### PR TITLE
download datum://id and datum://alias files, run execution locally, using project data files

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,2 +1,3 @@
 pytest-cov
 requests-mock
+valohai-cli

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,8 +1,11 @@
 import os
 import sys
 
+import pytest
+
 import valohai
 from valohai.internals.inputs import get_input_info, get_input_vfs
+from valohai_cli import settings as settings_module
 
 
 def test_download(tmpdir, monkeypatch, requests_mock):
@@ -63,3 +66,87 @@ def test_download(tmpdir, monkeypatch, requests_mock):
     get_input_vfs("example")
 
     assert requests_mock.call_count == 3
+
+
+@pytest.mark.parametrize(
+    "datum_name",
+    [
+        "01941935-832f-16d4-af69-6a9bf6bf4df6",
+        "my_models_alias",
+    ],
+)
+def test_datum_url_download(tmpdir, monkeypatch, requests_mock, datum_name):
+    inputs_dir = str(tmpdir.mkdir("inputs"))
+    project_dir = str(tmpdir.mkdir("project"))
+    monkeypatch.setenv("VH_INPUTS_DIR", inputs_dir)
+
+    project_id = "018a5fc7-02f8-d42d-a22b-cb6ffe20919e"
+    datum_id = "01941935-832f-16d4-af69-6a9bf6bf4df6"
+    datum_alias = "my_models_alias"
+    vh_host = "https://app.valohai.com"
+    filename = "t10k-images-idx3-ubyte.gz"
+    file_sha256 = "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589"
+
+    # Final file to download
+    requests_mock.get(
+        f"https://valohai-mnist.s3.amazonaws.com/{filename}",
+        text="abcd",
+    )
+    # Project API is required to log in to CLI
+    requests_mock.get(
+        f"{vh_host}/api/v0/projects/{project_id}/",
+        json={
+            "name": "Good Project",
+            "id": project_id,
+        },
+    )
+    # Datum by alias lookup API
+    requests_mock.get(
+        f"{vh_host}/api/v0/datum-aliases/resolve/?name={datum_alias}&project={project_id}",
+        json={
+            "datum": {
+                "name": filename,
+                "id": datum_id,
+                "sha256": file_sha256,
+            }
+        },
+    )
+    # Datum by exact ID API
+    requests_mock.get(
+        f"{vh_host}/api/v0/data/{datum_id}",
+        json={
+            "name": filename,
+            "id": datum_id,
+            "sha256": file_sha256,
+        },
+    )
+    # Datum download API
+    requests_mock.get(
+        f"{vh_host}/api/v0/data/{datum_id}/download/",
+        json={"url": f"https://valohai-mnist.s3.amazonaws.com/{filename}"},
+    )
+
+    # Set up CLI -- it is required for datum URL downloads
+    cli_settings = settings_module.Settings()
+    cli_settings.overrides["host"] = vh_host
+    cli_settings.overrides["token"] = "a token"
+    monkeypatch.setattr(settings_module, "settings", cli_settings)
+
+    cli_settings.set_override_project(
+        project_id=project_id,
+        directory=project_dir,
+        mode="remote",
+    )
+
+    inputs = {
+        "example": f"datum://{datum_name}",
+    }
+
+    monkeypatch.setattr(sys, "argv", ["myscript.py"])
+    valohai.prepare(step="test", default_inputs=inputs)
+
+    # This triggers the download
+    get_input_vfs("example")
+
+    assert os.path.isfile(os.path.join(inputs_dir, "example", filename))
+    assert requests_mock.call_count == 4


### PR DESCRIPTION
As discussed in the Continental support channel, we need the possibility to download datum:// input files to run an execution locally. This pull request adds this feature to valohai-utils' download.py.
Using this we were able to run a complete execution, locally.

To test, perform the following steps
- log in to valohai with `vh login`
- link a project, if you want to use aliases with `vh link`
- execute python snippet (make sure to replace `my_models_alias` and `01941935-832f-16d4-af69-6a9bf6bf4df6` with existent data)

```python
import valohai

valohai.prepare(
    step="predict",
    default_inputs={
        "model-http": "http://example.com",
        "model-alias": "datum://my_models_alias",
        "model-id": "datum://01941935-832f-16d4-af69-6a9bf6bf4df6",
    },
)

print(valohai.inputs("model-http").path())
print(valohai.inputs("model-id").path())
print(valohai.inputs("model-alias").path())
```