### PR TITLE
add upload_store as prepare parameter

### DIFF
--- a/valohai/internals/global_state.py
+++ b/valohai/internals/global_state.py
@@ -9,13 +9,14 @@ parameters: Dict[str, Any] = {}
 step_name: Optional[str] = None
 image_name: Optional[str] = None
 environment: Optional[str] = None
+upload_store: Optional[str] = None
 distributed = Distributed()
 multifile: bool = False
 
 
 def flush_global_state() -> None:
     # fmt: off
-    global loaded, inputs, parameters, step_name, image_name, distributed, environment, multifile
+    global loaded, inputs, parameters, step_name, image_name, distributed, environment, upload_store, multifile
     # fmt: off
     loaded = False
     inputs = {}
@@ -23,5 +24,6 @@ def flush_global_state() -> None:
     step_name = None
     image_name = None
     environment = None
+    upload_store = None
     multifile = False
     distributed.flush_state()

--- a/valohai/internals/parsing.py
+++ b/valohai/internals/parsing.py
@@ -13,7 +13,7 @@ def is_module_function_call(node: ast.Call, module: str, function: str) -> bool:
 
 
 ParseResult = namedtuple(
-    "ParseResult", ["step", "parameters", "inputs", "image", "environment", "multifile"]
+    "ParseResult", ["step", "parameters", "inputs", "image", "environment", "multifile", "upload_store"]
 )
 
 
@@ -61,6 +61,7 @@ class PrepareParser(ast.NodeVisitor):
         self.image = None
         self.environment = None
         self.multifile = False
+        self.upload_store = None
 
     def visit_Assign(self, node: ast.Assign | ast.AnnAssign) -> None:
         if hasattr(node, "targets"):
@@ -108,6 +109,8 @@ class PrepareParser(ast.NodeVisitor):
                     self.environment = ast.literal_eval(key.value)
                 elif key.arg == "multifile":
                     self.multifile = bool(ast.literal_eval(key.value))
+                elif key.arg == "upload_store":
+                    self.upload_store = ast.literal_eval(key.value)
 
     def _process_kwarg(self, key: ast.keyword, *, error_hint: str = "") -> Any:
         if isinstance(key.value, ast.Name) and key.value.id in self.assignments:
@@ -134,4 +137,5 @@ def parse(source: str) -> ParseResult:
         image=parser.image,
         environment=parser.environment,
         multifile=parser.multifile,
+        upload_store=parser.upload_store,
     )

--- a/valohai/internals/yaml.py
+++ b/valohai/internals/yaml.py
@@ -25,6 +25,7 @@ def generate_step(
     inputs: Dict[str, Any],
     environment: Optional[str] = None,
     multifile: bool = False,
+    upload_store: Optional[str] = None,
 ) -> Step:
     # We need to generate a POSIX-compliant command, even if we are running this method in Windows
     # The path separator must be forced to POSIX
@@ -35,6 +36,7 @@ def generate_step(
         command=get_command(relative_source_path, multifile=multifile),
         source_path=relative_source_path if multifile else None,
         environment=environment,
+        upload_store=upload_store,
     )
 
     for key, value in parameters.items():
@@ -93,6 +95,7 @@ def generate_config(
     inputs: InputDict,
     environment: Optional[str] = None,
     multifile: bool = False,
+    upload_store: Optional[str] = None,
 ) -> Config:
     step_obj = generate_step(
         relative_source_path=relative_source_path,
@@ -102,6 +105,7 @@ def generate_config(
         inputs=inputs,
         environment=environment,
         multifile=multifile,
+        upload_store=upload_store,
     )
     config = Config()
     config.steps[step_obj.name] = step_obj
@@ -140,6 +144,7 @@ def parse_config_from_source(source_path: str, config_path: str) -> Config:
         parameters=parsed.parameters,
         inputs=parsed.inputs,
         multifile=parsed.multifile,
+        upload_store=parsed.upload_store,
     )
 
 

--- a/valohai/prepare_impl.py
+++ b/valohai/prepare_impl.py
@@ -13,6 +13,7 @@ def prepare(
     image: Optional[str] = None,
     environment: Optional[str] = None,
     multifile: bool = False,
+    upload_store: Optional[str] = None,
 ) -> None:
     """Define the name of the step and its required inputs, parameters and Docker image
 
@@ -26,13 +27,14 @@ def prepare(
     :param image: Default docker image
     :param environment: Default environment ID or slug
     :param multifile: allow step to be prepared from multiple different source files
-
+    :param upload_store: Upload store UUID for storing execution outputs
     """
 
     global_state.step_name = step
     global_state.image_name = image
     global_state.environment = environment
     global_state.multifile = multifile
+    global_state.upload_store = upload_store
 
     load_global_state(
         default_inputs_from_prepare=default_inputs,


### PR DESCRIPTION
Hi all,
this will add upload_store as parameter to the prepare function to make it possible to specify this yaml entry through the step's .py file.

Example:
```
valohai.prepare(
    step="training-step",
    image="docker.io/myorg/training:1.0",
    default_inputs=default_inputs,
    default_parameters=default_parameters,
    upload_store="abc123de-f456-7890-ghij-klmnopqrstuv"  # UUID of your upload store
)
```

You will need to bump the version as well and set it in valohai-cli.

### Addition:

Please also update the documentation for visibility of this feature or point me to the docs repo (I couldn't find a public one).

Also, please mention in the documentation how to specify parameter descriptions. This is not well documented yet either.
Example:
```
default_params = {
    "parameter_name": {
        "default": "default_value",
        "description": "helpful description here",
        "optional": True,
        "type": "string"
    },
    ...
}
```