### PR TITLE
Update default Python image

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Will produce this `valohai.yaml` config:
 ```yaml
 - step:
     name: resize
-    image: python:3.7
+    image: python:3.11-slim
     command: python ./resize.py {parameters}
     parameters:
     - name: width

--- a/tests/test_yaml/test1.expected.valohai.yaml
+++ b/tests/test_yaml/test1.expected.valohai.yaml
@@ -4,7 +4,7 @@
     command: python ./yomama.py {parameters}
 - step:
     name: foobar1
-    image: python:3.7
+    image: python:3.11-slim
     command:
     - pip install -r requirements.txt
     - python ./test1.py {parameters}

--- a/tests/test_yaml/test3.expected.valohai.yaml
+++ b/tests/test_yaml/test3.expected.valohai.yaml
@@ -1,6 +1,6 @@
 - step:
     name: foobar1
-    image: python:3.7
+    image: python:3.11-slim
     command:
     - pip install -r requirements.txt
     - python ./test3.py {parameters}

--- a/tests/test_yaml/test4.expected.valohai.yaml
+++ b/tests/test_yaml/test4.expected.valohai.yaml
@@ -1,6 +1,6 @@
 - step:
     name: foobar1
-    image: python:3.7
+    image: python:3.11-slim
     command: python ./test.py {parameters}
     parameters:
     - name: param1

--- a/tests/test_yaml/test4.original.valohai.yaml
+++ b/tests/test_yaml/test4.original.valohai.yaml
@@ -1,6 +1,6 @@
 - step:
     name: foobar1
-    image: python:3.7
+    image: python:3.11-slim
     command: python ./test.py {parameters}
     parameters:
     - name: param1

--- a/tests/test_yaml/test5.original.valohai.yaml
+++ b/tests/test_yaml/test5.original.valohai.yaml
@@ -1,6 +1,6 @@
 - step:
     name: mystep
-    image: python:3.7
+    image: python:3.11-slim
     command: python ./test.py {parameters}
     parameters:
     - name: seq_length

--- a/valohai/consts.py
+++ b/valohai/consts.py
@@ -1,4 +1,4 @@
-DEFAULT_DOCKER_IMAGE = "python:3.7"
+DEFAULT_DOCKER_IMAGE = "python:3.11-slim"
 VH_LOCAL_CONFIG_DIR = ".valohai/config"
 VH_LOCAL_INPUTS_DIR = ".valohai/inputs"
 VH_LOCAL_OUTPUTS_DIR = ".valohai/outputs"


### PR DESCRIPTION
Using a more modern Python image by default instead of one way past end of life.

`vh yaml step FILE.PY` uses this image as a default.

There have been some issues e.g. with PyTorch with images newer than 3.11, so we’ll use that as the default for now.

The slim image is much smaller (~87%) than the regular Python image, and should work with most things just fine, so setting that as the default is good for making the executions more nimble.