### PR TITLE
Support requesting on-demand inputs when using valohai input utilities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,8 @@ def vte(tmpdir):
 def use_test_config_dir(vte, monkeypatch):
     vte.build()
     monkeypatch.setenv("VH_CONFIG_DIR", str(vte.config_path))
-    monkeypatch.setenv("VH_INPUT_DIR", str(vte.inputs_path))
-    monkeypatch.setenv("VH_OUTPUT_DIR", str(vte.outputs_path))
+    monkeypatch.setenv("VH_INPUTS_DIR", str(vte.inputs_path))
+    monkeypatch.setenv("VH_OUTPUTS_DIR", str(vte.outputs_path))
 
     # pytest carries global state between tests if we don't flush it
     global_state.flush_global_state()


### PR DESCRIPTION
If accessing inputs using `valohai.input('...')` that have not been downloaded, check if we have the necessary input metadata and API endpoint access to get download URLs for those inputs and download them before proceeding.