### PR TITLE
Output properties helper

### DIFF
--- a/tests/test_output_properties.py
+++ b/tests/test_output_properties.py
@@ -1,0 +1,97 @@
+"""Test handling the execution output metadata properties."""
+
+import json
+import logging
+import random
+import string
+import time
+from pathlib import Path
+
+import pytest  # type: ignore
+
+import valohai
+
+
+logger = logging.getLogger(__name__)
+
+
+def test_create_properties(tmp_metadata_file):
+    """Test creating a properties file."""
+    with valohai.output_properties() as properties:
+        properties.properties_file = tmp_metadata_file
+
+        # file in the outputs directory
+        properties.set(file="file.txt", properties={"foo": "bar"})
+        # file in a subdirectory
+        properties.set(file="path/to/file.txt", properties={"baz": "qux"})
+        # file can also be a Path object
+        properties.set(
+            file=Path("path/to/another/file.txt"), properties={"quux": "quuz"}
+        )
+
+        # check that the properties are set
+        assert properties._files_properties.get("file.txt") == {"foo": "bar"}
+        assert properties._files_properties.get("path/to/file.txt") == {"baz": "qux"}
+        assert properties._files_properties.get("path/to/another/file.txt") == {
+            "quux": "quuz"
+        }
+
+    # check that the properties are saved to the file
+    saved_properties = read_json_lines(tmp_metadata_file)
+    assert saved_properties.get("file.txt") == {"foo": "bar"}
+    assert saved_properties.get("path/to/file.txt") == {"baz": "qux"}
+    assert saved_properties.get("path/to/another/file.txt") == {"quux": "quuz"}
+
+
+def test_large_number_of_files(tmp_metadata_file, random_string):
+    """Test handling metadata for a very large number of outputs."""
+    test_properties = {
+        "foo": "bar",
+        "baz": "this is a longer metadata string",
+        "random": random_string,
+        "number": 42,
+    }
+    nr_of_files = 100_000
+
+    start = time.perf_counter()
+    with valohai.output_properties() as properties:
+        properties.properties_file = tmp_metadata_file
+
+        for i in range(nr_of_files):
+            properties.set(file=f"file_{i}.txt", properties=test_properties)
+    end = time.perf_counter()
+
+    assert (
+        len(properties.properties_file.read_bytes().splitlines()) == nr_of_files
+    ), "Should have written all entries to file"
+
+    elapsed_time = end - start
+    logger.debug(f"File entries: {nr_of_files:,}; elapsed time: {elapsed_time:.2f} s")
+    assert (
+        elapsed_time < 2.0
+    ), "Should actually be under 1 second; something has changed considerably"
+
+
+def read_json_lines(properties_file: Path):
+    """
+    Read a saved properties JSON lines file back into a dictionary.
+    Dictionary format: {file_path: metadata, ...}
+    """
+    return {
+        entry["file"]: entry["metadata"]
+        for entry in (
+            json.loads(line) for line in properties_file.read_bytes().splitlines()
+        )
+    }
+
+
+@pytest.fixture
+def tmp_metadata_file(tmp_path) -> Path:
+    return tmp_path / "valohai.metadata.jsonl"
+
+
+@pytest.fixture
+def random_string() -> str:
+    length = 1000
+    keyspace: str = string.ascii_letters + string.digits
+    return "".join(random.choice(keyspace) for _ in range(length))

--- a/tests/test_output_properties.py
+++ b/tests/test_output_properties.py
@@ -21,11 +21,11 @@ def test_create_properties(tmp_metadata_file):
         properties.properties_file = tmp_metadata_file
 
         # file in the outputs directory
-        properties.set(file="file.txt", properties={"foo": "bar"})
+        properties.add(file="file.txt", properties={"foo": "bar"})
         # file in a subdirectory
-        properties.set(file="path/to/file.txt", properties={"baz": "qux"})
+        properties.add(file="path/to/file.txt", properties={"baz": "qux"})
         # file can also be a Path object
-        properties.set(
+        properties.add(
             file=Path("path/to/another/file.txt"), properties={"quux": "quuz"}
         )
 
@@ -41,6 +41,26 @@ def test_create_properties(tmp_metadata_file):
     assert saved_properties.get("file.txt") == {"foo": "bar"}
     assert saved_properties.get("path/to/file.txt") == {"baz": "qux"}
     assert saved_properties.get("path/to/another/file.txt") == {"quux": "quuz"}
+
+
+def test_add_to_existing_properties(tmp_metadata_file):
+    """You can add new properties to a file that already has properties."""
+    with valohai.output_properties() as properties:
+        properties.properties_file = tmp_metadata_file
+
+        properties.add(
+            file="file.txt", properties={"foo": "bar", "baz": "will be overwritten"}
+        )
+        properties.add(
+            file="file.txt", properties={"baz": "can overwrite existing value"}
+        )
+        properties.add(file="file.txt", properties={"corge": "can add new properties"})
+
+    assert properties._files_properties.get("file.txt") == {
+        "foo": "bar",
+        "baz": "can overwrite existing value",
+        "corge": "can add new properties",
+    }
 
 
 def test_add_files_to_dataset(tmp_path, random_string):

--- a/valohai/__init__.py
+++ b/valohai/__init__.py
@@ -6,6 +6,7 @@ from valohai.controller_api import set_status_detail
 from valohai.inputs import inputs
 from valohai.internals.global_state import distributed
 from valohai.metadata import logger
+from valohai.output_properties import output_properties
 from valohai.outputs import outputs
 from valohai.parameters import parameters
 from valohai.prepare_impl import prepare
@@ -17,6 +18,7 @@ __all__ = [
     "distributed",
     "inputs",
     "logger",
+    "output_properties",
     "outputs",
     "parameters",
     "prepare",

--- a/valohai/output_properties.py
+++ b/valohai/output_properties.py
@@ -34,7 +34,7 @@ class OutputProperties:
         self._initialize_existing_properties()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore[no-untyped-def]
         self._save()
         self._log_created_datasets()
 
@@ -85,7 +85,7 @@ class OutputProperties:
         except FileNotFoundError:
             return
 
-    def _save(self):
+    def _save(self) -> None:
         self.properties_file.write_text(
             "".join(
                 format_line(file_path, file_metadata)
@@ -93,7 +93,7 @@ class OutputProperties:
             )
         )
 
-    def _log_created_datasets(self):
+    def _log_created_datasets(self) -> None:
         """Print out a summary of created datasets to the execution log."""
         datasets = [
             file_metadata["valohai.dataset-versions"]

--- a/valohai/output_properties.py
+++ b/valohai/output_properties.py
@@ -53,6 +53,23 @@ class OutputProperties:
         """
         self._files_properties[str(file)].update(properties)
 
+    def add_to_dataset(self, *, file: File, dataset_version: DatasetVersionURI) -> None:
+        """
+        Add a file to a dataset.
+
+        Args:
+            file: The path to the file (relative to the execution outputs root directory).
+            dataset_version: The dataset version to add the file to.
+        """
+        dataset_versions = set(
+            self._files_properties[str(file)].get("valohai.dataset-versions", [])
+        )
+        dataset_versions.add(dataset_version)
+        self.add(
+            file=file,
+            properties={"valohai.dataset-versions": list(dataset_versions)},
+        )
+
     def set(
         self,
         *,
@@ -76,7 +93,7 @@ class OutputProperties:
         self._files_properties[str(file)] = {**props, **dataset_props}
 
     @staticmethod
-    def dataset_uri(dataset: str, version: str) -> DatasetVersionURI:
+    def dataset_version_uri(dataset: str, version: str) -> DatasetVersionURI:
         """Return the dataset URI for the given dataset and version."""
         return f"dataset://{dataset}/{version}"
 

--- a/valohai/output_properties.py
+++ b/valohai/output_properties.py
@@ -1,0 +1,72 @@
+"""Execution output properties helper.
+
+The properties are saved in a `valohai.metadata.jsonl` file in the outputs directory
+in JSON lines format.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Union, Dict, Optional
+
+from valohai.paths import get_outputs_path
+
+File = Union[str, Path]  # path to the file (relative to outputs directory)
+Properties = Dict[str, Any]  # metadata properties for a file
+FilesProperties = Dict[File, Properties]
+
+
+class OutputProperties:
+    """Helper for setting properties for output files."""
+
+    _files_properties: FilesProperties
+
+    def __init__(self) -> None:
+        self._files_properties = {}
+        self.properties_file = Path(get_outputs_path()) / "valohai.metadata.jsonl"
+
+    def __enter__(self) -> "OutputProperties":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self._save()
+
+    def set(self, *, file: File, properties: Optional[Properties] = None) -> None:
+        """
+        Set properties for a file.
+        If the file already has properties, they will be overwritten.
+
+        Args:
+            file: The path to the file (relative to the execution outputs root directory).
+            properties: The metadata properties for the file.
+        """
+        props: Properties = properties or {}
+        self._files_properties[str(file)] = props
+
+    def _save(self):
+        Path(self.properties_file).write_text(
+            "".join(
+                format_line(file_path, file_metadata)
+                for file_path, file_metadata in self._files_properties.items()
+            )
+        )
+
+
+output_properties = OutputProperties
+
+
+def format_line(file_path: File, file_metadata: Properties) -> str:
+    """Format metadata for an output file into a format Valohai understands.
+
+    Args:
+        file_path: The path to the file (relative to the execution outputs root directory).
+        file_metadata: The metadata for the file.
+    """
+    return (
+        json.dumps(
+            {
+                "file": file_path,
+                "metadata": file_metadata,
+            }
+        )
+        + "\n"
+    )

--- a/valohai/output_properties.py
+++ b/valohai/output_properties.py
@@ -70,28 +70,6 @@ class OutputProperties:
             properties={"valohai.dataset-versions": list(dataset_versions)},
         )
 
-    def set(
-        self,
-        *,
-        file: File,
-        properties: Optional[Properties] = None,
-        datasets: Optional[List[DatasetVersionURI]] = None,
-    ) -> None:
-        """
-        Set properties for a file.
-        If the file already has properties, they will be overwritten.
-
-        Args:
-            file: The path to the file (relative to the execution outputs root directory).
-            properties: The metadata properties for the file.
-            datasets: List of URIs of the dataset versions the file belongs to.
-        """
-        props: Properties = properties or {}
-        dataset_props: Properties = (
-            {"valohai.dataset-versions": datasets} if datasets else {}
-        )
-        self._files_properties[str(file)] = {**props, **dataset_props}
-
     @staticmethod
     def dataset_version_uri(dataset: str, version: str) -> DatasetVersionURI:
         """Return the dataset URI for the given dataset and version."""


### PR DESCRIPTION
Resolves #138 

Add a helper class that takes care of execution output properties handling:

- file name & location
- JSON lines format
- opening file, writing data, closing file

When creating datasets, a summary is output to the execution log: created dataset versions & how many files were included.

Tests include a metadata handler for 100 000 files, the code scales pretty linearly upwards from that (tested manually with 1 million metadata entries).

This version is a bit more simplified than earlier drafts: adding files to datasets is done separately from adding the other properties; this is to keep the user interface as simple and easy as possible (and it also accommodates the most usual use cases better).

Example usage:

```python
with valohai.output_properties() as properties:
    dataset_version = properties.dataset_version_uri("dataset-name", "version-name")
    properties.add(file="my_output.txt", properties={"prop_name": "value", "number_prop": 1.3})
    properties.add(file="my_output.txt", properties={"another_prop": True}
    properties.add_to_dataset(file="my_output.txt", dataset_version=dataset_version)
```
