### PR TITLE
Pin CI test to Ubuntu 22.04, the last version that supports Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ name: CI
 
 jobs:
   Test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
The minimum Python version will be raised later, as Python 3.7 is at end of life.

Ref https://github.com/actions/runner-images/issues/10636