### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ name: CI
 
 jobs:
   Test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.7"
+        python-version: "3.8"
         cache: pip
         cache-dependency-path: '**/setup.cfg'
     - name: Install
@@ -29,7 +29,7 @@ jobs:
     - name: Test with pytest
       run: pytest -ra --cov .
   Typecheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -42,13 +42,13 @@ jobs:
       run: python -m pip install -r requirements-typecheck.txt -e .
     - run: mypy --strict .
   Lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
     - uses: pre-commit/action@v3.0.1
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -69,7 +69,7 @@ jobs:
     needs:
       - Build
     name: Upload release to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: release
       url: https://pypi.org/p/valohai-utils/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "valohai-utils"
 dynamic = ["version"]
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Valohai", email = "hait@valohai.com" },
 ]
@@ -32,7 +32,7 @@ packages = [
 
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.lint]
 ignore = [

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,3 +1,4 @@
 pytest-cov
 requests-mock
 valohai-cli
+valohai-yaml>=0.46.0  # required for stable YAML generation

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import dataclasses
 import glob
 import json
 import os
+import pytest
 
 from difflib import unified_diff as diff
 
@@ -75,10 +76,11 @@ def read_yaml_test_data(root_path):
         dirname = os.path.dirname(source_path)
         name, extension = os.path.splitext(os.path.basename(source_path))
         test_data.append(
-            (
+            pytest.param(
                 f"{dirname}/{name}.original.valohai.yaml",
                 source_path,
                 f"{dirname}/{name}.expected.valohai.yaml",
+                id=f"{dirname}/{name}",
             )
         )
     return test_data


### PR DESCRIPTION
Python 3.7 has been EOL for 18 months now. Our other software doesn't support it anymore either.

